### PR TITLE
Allow user to specify access/secret keys via profile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 configargparse
+configparser

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         'requests',
         'configargparse',
+        'configparser',
         'urllib3[secure]'
     ]
 )


### PR DESCRIPTION
Also use 'default' profile by default. The profile is only used if access or secret keys are not provided