### PR TITLE
If no credentials are specified, try and retrieve some temporary credentials via STS and the IAM Instance Profile in EC2

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -13,6 +13,8 @@ import configargparse
 import configparser
 import requests
 
+from botocore.credentials import InstanceMetadataProvider, InstanceMetadataFetcher
+
 __author__ = 'iokulist'
 
 
@@ -94,6 +96,17 @@ def make_request(method,
         k_service = sign(k_region, service_name)
         k_signing = sign(k_service, 'aws4_request')
         return k_signing
+
+    # Try and get credentials from an IAM Instance Profile via STS
+    if access_key is None or secret_key is None:
+        provider = InstanceMetadataProvider(
+            iam_role_fetcher=InstanceMetadataFetcher()
+        )
+        creds = provider.load()
+        if creds:
+            access_key = creds.access_key
+            secret_key = creds.secret_key
+            security_token = creds.token
 
     if access_key is None or secret_key is None:
         try:

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -13,7 +13,10 @@ import configargparse
 import configparser
 import requests
 
-from botocore.credentials import InstanceMetadataProvider, InstanceMetadataFetcher
+from botocore.credentials import (
+    InstanceMetadataProvider,
+    InstanceMetadataFetcher
+)
 
 __author__ = 'iokulist'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 configargparse
 configparser
+botocore


### PR DESCRIPTION
If not available, continue attempting to retrieve credentials the same way as
before

Fixes #16