### PR TITLE
Fixes issues with unicode hashing in python 3

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -95,6 +95,9 @@ def make_request(method,
         k_signing = sign(k_service, 'aws4_request')
         return k_signing
 
+    def sha256_hash(val):
+        return hashlib.sha256(val.encode('utf-8')).hexdigest()
+
     if access_key is None or secret_key is None:
         try:
             config = configparser.ConfigParser()
@@ -164,7 +167,7 @@ def make_request(method,
 
     # Step 6: Create payload hash (hash of the request body content). For GET
     # requests, the payload is an empty string ("").
-    payload_hash = hashlib.sha256(data).hexdigest()
+    payload_hash = sha256_hash(data)
 
     # Step 7: Combine elements to create create canonical request
     canonical_request = (method + '\n' +
@@ -186,7 +189,7 @@ def make_request(method,
     string_to_sign = (algorithm + '\n' +
                       amzdate + '\n' +
                       credential_scope + '\n' +
-                      hashlib.sha256(canonical_request).hexdigest())
+                      sha256_hash(canonical_request))
 
     log('\nSTRING_TO_SIGN = ' + string_to_sign)
     # ************* TASK 3: CALCULATE THE SIGNATURE *************


### PR DESCRIPTION
I was getting exceptions when running this in python 3.6.0:

```
Traceback (most recent call last):
  File "/Users/amatheny/.pyenv/versions/3.6.0/bin/awscurl", line 11, in <module>
    load_entry_point('awscurl==0.8', 'console_scripts', 'awscurl')()
  File "/Users/amatheny/.pyenv/versions/3.6.0/lib/python3.6/site-packages/awscurl/awscurl.py", line 311, in main
    args.security_token
  File "/Users/amatheny/.pyenv/versions/3.6.0/lib/python3.6/site-packages/awscurl/awscurl.py", line 161, in make_request
    payload_hash = hashlib.sha256(data).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```
This PR fixes that issue