### PR TITLE
Default region to AWS_DEFAULT_REGION

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -274,7 +274,10 @@ def main():
     parser.add_argument('-d', '--data', help='HTTP POST data', default='')
     parser.add_argument('-H', '--header', help='HTTP header', action='append')
 
-    parser.add_argument('--region', help='AWS region', default='us-east-1')
+    parser.add_argument('--region',
+                        help='AWS region',
+                        default='us-east-1',
+                        env_var='AWS_DEFAULT_REGION')
     parser.add_argument('--profile',
                         help='AWS profile',
                         default='default',


### PR DESCRIPTION
This PR adds the argparse setting to default region to `AWS_DEFAULT_REGION` which goes along with https://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variable-configuration