### PR TITLE
Don't log unless verbose arg is passed in

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -17,6 +17,7 @@ __author__ = 'iokulist'
 
 is_verbose = False
 
+
 def log(*args, **kwargs):
     if not is_verbose:
         return

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -15,8 +15,11 @@ import requests
 
 __author__ = 'iokulist'
 
+is_verbose = False
 
 def log(*args, **kwargs):
+    if not is_verbose:
+        return
     pp = pprint.PrettyPrinter(stream=sys.stderr)
     pp.pprint(*args, **kwargs)
 
@@ -290,6 +293,8 @@ def main():
     parser.add_argument('uri')
 
     args = parser.parse_args()
+    global is_verbose
+    is_verbose = args.verbose
 
     if args.verbose:
         log(vars(parser.parse_args()))


### PR DESCRIPTION
Changes log method to only output when verbose is set.  This enables redirection into other scripts, files, etc.