### PR TITLE
Adding the option (-k) to ignore SSL verification errors.

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -59,7 +59,8 @@ def make_request(method,
                  access_key,
                  secret_key,
                  security_token,
-                 data_binary):
+                 data_binary,
+                 verify=True):
     """
     # Make HTTP request with AWS Version 4 signing
 
@@ -75,6 +76,7 @@ def make_request(method,
     :param secret_key: str
     :param security_token: str
     :param data_binary: bool
+    :param verify: bool
 
     See also: http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
     """
@@ -211,7 +213,7 @@ def make_request(method,
         'x-amz-content-sha256': payload_hash
     })
 
-    return __send_request(uri, data, headers, method)
+    return __send_request(uri, data, headers, method, verify)
 
 
 def __normalize_query_string(query):
@@ -228,14 +230,14 @@ def __now():
     return datetime.datetime.utcnow()
 
 
-def __send_request(uri, data, headers, method):
+def __send_request(uri, data, headers, method, verify):
     __log('\nHEADERS++++++++++++++++++++++++++++++++++++')
     __log(headers)
 
     __log('\nBEGIN REQUEST++++++++++++++++++++++++++++++++++++')
     __log('Request URL = ' + uri)
 
-    r = requests.request(method, uri, headers=headers, data=data)
+    r = requests.request(method, uri, headers=headers, data=data, verify=verify)
 
     __log('\nRESPONSE++++++++++++++++++++++++++++++++++++')
     __log('Response code: %d\n' % r.status_code)
@@ -295,6 +297,9 @@ def main():
                         default='GET')
     parser.add_argument('-d', '--data', help='HTTP POST data', default='')
     parser.add_argument('-H', '--header', help='HTTP header', action='append')
+    parser.add_argument('-k', '--insecure', action='store_false',
+                        help='This option allows awscurl to proceed and operate even for server '
+                             'connections otherwise considered insecure')
 
     parser.add_argument('--data-binary', action='store_true',
                         help='Process HTTP POST data exactly as specified with '
@@ -351,7 +356,8 @@ def main():
                      args.access_key,
                      args.secret_key,
                      args.security_token or args.session_token,
-                     args.data_binary
+                     args.data_binary,
+                     args.insecure
                      )
 
     print(r.text)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -9,6 +9,9 @@ from mock import patch
 
 from awscurl.awscurl import make_request
 
+from requests.exceptions import SSLError
+
+import pytest
 __author__ = 'iokulist'
 
 
@@ -35,6 +38,23 @@ def my_mock_send_request():
         response = Object()
         response.status_code = 200
         response.text = 'some text'
+        return response
+
+    return ss
+
+
+def my_mock_send_request_verify():
+    class Object():
+        pass
+
+    def ss(uri, data, headers, method, verify, **kargs):
+        print("in mock")
+        if not verify:
+            raise SSLError
+        response = Object()
+        response.status_code = 200
+        response.text = 'some text'
+
         return response
 
     return ss
@@ -69,6 +89,60 @@ class TestMakeRequest(TestCase):
                   'secret_key': '',
                   'security_token': '',
                   'data_binary': False}
+        make_request(**params)
+
+        expected = {'x-amz-date': '19700101T000000Z',
+                    'Authorization': 'AWS4-HMAC-SHA256 Credential=/19700101/region/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=de2b9ea384c10b03314afa10532adac358f8c93e3f3dd5bd724eda24a367a7ef',
+                    'x-amz-content-sha256': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+                    'x-amz-security-token': ''}
+
+        self.assertEqual(expected, headers)
+
+        pass
+
+
+class TestMakeRequestVerifySSLRaises(TestCase):
+    maxDiff = None
+
+    @patch('awscurl.awscurl.__send_request', new_callable=my_mock_send_request_verify)
+    @patch('awscurl.awscurl.__now', new_callable=my_mock_utcnow)
+    def test_make_request(self, *args, **kvargs):
+        headers = {}
+        params = {'method': 'GET',
+                  'service': 'ec2',
+                  'region': 'region',
+                  'uri': 'https://user:pass@host:123/path/?a=b&c=d',
+                  'headers': headers,
+                  'data': '',
+                  'access_key': '',
+                  'secret_key': '',
+                  'security_token': '',
+                  'data_binary': False,
+                  'verify': False}
+
+        with pytest.raises(SSLError):
+            make_request(**params)
+
+        pass
+
+class TestMakeRequestVerifySSLPass(TestCase):
+    maxDiff = None
+
+    @patch('awscurl.awscurl.__send_request', new_callable=my_mock_send_request_verify)
+    @patch('awscurl.awscurl.__now', new_callable=my_mock_utcnow)
+    def test_make_request(self, *args, **kvargs):
+        headers = {}
+        params = {'method': 'GET',
+                  'service': 'ec2',
+                  'region': 'region',
+                  'uri': 'https://user:pass@host:123/path/?a=b&c=d',
+                  'headers': headers,
+                  'data': '',
+                  'access_key': '',
+                  'secret_key': '',
+                  'security_token': '',
+                  'data_binary': False,
+                  'verify': True}
         make_request(**params)
 
         expected = {'x-amz-date': '19700101T000000Z',


### PR DESCRIPTION
## Why?

There might be situations where clients issue their own SSL certificates used in their organization. 

In such a case, `awscurl` will fail to execute due to SSL Verification failure. 

## Description

Adding the parameter `-k` will replicate the functionality in `curl` 

## Testing
### Verification Failure
```
awscurl https://test-api.mydomain.com --service myservice --region us-west-2
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 601, in urlopen
    chunked=chunked)
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 346, in _make_request
    self._validate_conn(conn)
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 850, in _validate_conn
    conn.connect()
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 326, in connect
    ssl_context=context)
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/ssl_.py", line 329, in ssl_wrap_socket
    return context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ssl.py", line 407, in wrap_socket
    _context=self, _session=session)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ssl.py", line 814, in __init__
    self.do_handshake()
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ssl.py", line 1068, in do_handshake
    self._sslobj.do_handshake()
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ssl.py", line 689, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:833)
```

### Ignore Verification Failure
```
awscurl https://test-api.mydomain.com --service myservice --region us-west-2  -k
/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{"errors":[{"message":"POST body sent invalid JSON."}]}
```

### Unit tests passing

```
pytest --verbose --cov-report term-missing --cov ./ -s
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.6.5, pytest-3.5.0, py-1.5.3, pluggy-0.6.0 -- /usr/local/opt/python/bin/python3.6
cachedir: .pytest_cache
rootdir: /Users/iulianm/github-repos/awscurl, inifile:
plugins: cov-2.5.1
collected 10 items

tests/basic_test.py::ShallPassTest::test PASSED
tests/integration_test.py::TestMakeRequestWithToken::test_make_request PASSED
tests/integration_test.py::TestMakeRequestWithTokenAndBinaryData::test_make_request PASSED
tests/load_aws_config_test.py::Test__load_aws_config::test PASSED
tests/unit_test.py::TestMakeRequest::test_make_request in mock
in mock
PASSED
tests/unit_test.py::TestMakeRequestVerifySSLRaises::test_make_request in mock
in mock
PASSED
tests/unit_test.py::TestMakeRequestVerifySSLPass::test_make_request in mock
in mock
PASSED
tests/unit_test.py::TestMakeRequestWithBinaryData::test_make_request in mock
in mock
PASSED
tests/unit_test.py::TestMakeRequestWithToken::test_make_request in mock
in mock
PASSED
tests/unit_test.py::TestMakeRequestWithTokenAndBinaryData::test_make_request in mock
in mock
PASSED

---------- coverage: platform darwin, python 3.6.5-final-0 -----------
Name                            Stmts   Miss  Cover   Missing
-------------------------------------------------------------
awscurl/__init__.py                 0      0   100%
awscurl/__main__.py                 5      5     0%   2-10
awscurl/awscurl.py                154     54    65%   24-25, 45, 48, 263, 266, 270-278, 285-367, 371
setup.py                            3      3     0%   1-5
tests/__init__.py                   0      0   100%
tests/basic_test.py                 6      0   100%
tests/integration_test.py          23      0   100%
tests/load_aws_config_test.py      11      0   100%
tests/unit_test.py                110      5    95%   23-27
-------------------------------------------------------------
TOTAL                             312     67    79%


============================================================================= 10 passed in 0.98 seconds =============================================================================
```