### PR TITLE
Locks urllib3 dependency to '<1.24,>=1.21.1' as required by requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
         'requests',
         'configargparse',
         'configparser',
-        'urllib3[secure]<1.24,>=1.21.1
+        'urllib3[secure]<1.24,>=1.21.1'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
         'requests',
         'configargparse',
         'configparser',
-        'urllib3[secure]'
+        'urllib3[secure]<1.24,>=1.21.1
     ]
 )


### PR DESCRIPTION
Fixes issue #50 