### PR TITLE
Add AWS instance support

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -279,7 +279,6 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
     return access_key, secret_key, security_token
 
 
-
 def main():
     # note EC2 ignores Accept header and responds in xml
     default_headers = ['Accept: application/xml',
@@ -349,15 +348,14 @@ def main():
             cred = session.get_credentials()
             if cred:
                 if not cred.refresh_needed():
-                    args.access_key, args.secret_key, args.security_token = cred.access_key,cred.secret_key,cred.token
+                    args.access_key, args.secret_key, args.security_token = cred.access_key, cred.secret_key, cred.token
                 else:
                     cred = session.get_credentials()
-                    args.access_key, args.secret_key, args.security_token = cred.access_key,cred.secret_key,cred.token
+                    args.access_key, args.secret_key, args.security_token = cred.access_key, cred.secret_key, cred.token
 
         except ImportError:
-           __log("couldn't find botocore package")
+            __log("couldn't find botocore package")
 
-        
     if args.access_key is None:
         raise ValueError('No access key is available')
 

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -12,7 +12,6 @@ import sys
 
 import configargparse
 import requests
-import botocore
 __author__ = 'iokulist'
 
 is_verbose = False
@@ -348,11 +347,12 @@ def main():
             import botocore.session
             session = botocore.session.get_session()
             cred = session.get_credentials()
-            if not cred.refresh_needed():
-                args.access_key, args.secret_key, args.security_token = cred.access_key,cred.secret_key,cred.token
-            else:
-                cred = session.get_credentials()
-                args.access_key, args.secret_key, args.security_token = cred.access_key,cred.secret_key,cred.token
+            if cred:
+                if not cred.refresh_needed():
+                    args.access_key, args.secret_key, args.security_token = cred.access_key,cred.secret_key,cred.token
+                else:
+                    cred = session.get_credentials()
+                    args.access_key, args.secret_key, args.security_token = cred.access_key,cred.secret_key,cred.token
 
         except ImportError:
            __log("couldn't find botocore package")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 configargparse
 configparser
+botocore


### PR DESCRIPTION
Allows awscurl to work on aws ec2 instances using the instance's IAM role.