### PR TITLE
Uses host from HTTP header to create canonical request instead of URI host

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -132,13 +132,13 @@ def make_request(method,
     canonical_querystring = __normalize_query_string(query)
     __log(canonical_querystring)
 
+    ## If the host was specified in the HTTP header, ensure that the canonical
+    ## headers are set accordingly
     if 'host' in headers:
         fullhost = headers['host']
     else:
-        fullhost = host
+        fullhost = host + ':' + port if port else host
 
-    if port:
-        fullhost = host + ':' + port
     # Step 4: Create the canonical headers and signed headers. Header names
     # and value must be trimmed and lowercase, and sorted in ASCII order.
     # Note that there is a trailing \n.

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -132,7 +132,11 @@ def make_request(method,
     canonical_querystring = __normalize_query_string(query)
     __log(canonical_querystring)
 
-    fullhost = host
+    if 'host' in headers:
+        fullhost = headers['host']
+    else:
+        fullhost = host
+
     if port:
         fullhost = host + ':' + port
     # Step 4: Create the canonical headers and signed headers. Header names

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -241,3 +241,33 @@ class TestMakeRequestWithTokenAndBinaryData(TestCase):
         self.assertEqual(expected, headers)
 
         pass
+
+class TestHostFromHeaderUsedInCanonicalHeader(TestCase):
+    maxDiff = None
+
+    @patch('requests.get', new_callable=my_mock_get)
+    @patch('awscurl.awscurl.__send_request', new_callable=my_mock_send_request)
+    @patch('awscurl.awscurl.__now', new_callable=my_mock_utcnow)
+    def test_make_request(self, *args, **kvargs):
+        headers = {'host': 'some.other.host.address.com'}
+        params = {'method': 'GET',
+                  'service': 'ec2',
+                  'region': 'region',
+                  'uri': 'https://user:pass@host:123/path/?a=b&c=d',
+                  'headers': headers,
+                  'data': '',
+                  'access_key': 'ABC',
+                  'secret_key': 'DEF',
+                  'security_token': 'GHI',
+                  'data_binary': False}
+        make_request(**params)
+
+        expected = {'host': 'some.other.host.address.com',
+                    'x-amz-date': '19700101T000000Z',
+                    'x-amz-content-sha256': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+                    'Authorization': 'AWS4-HMAC-SHA256 Credential=ABC/19700101/region/ec2/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=9cba1c499417655c170f5018b577b9f89154cf9b9827273df54bfa182e5f4273',
+                    'x-amz-security-token': 'GHI'}
+
+        self.assertEqual(expected, headers)
+
+        pass


### PR DESCRIPTION
If 'host' is passed as an HTTP header, make it part of the canonical request. If this does not happen, the host extracted from the URI will be used to create the canonical header. The mismatch between host header and header listed in the canonical request will authentication failures, as the signature is calculated over the entire request