### PR TITLE
Split up signature generation steps and add tests

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -11,6 +11,7 @@ import os
 import pprint
 import sys
 import re
+import copy
 
 import configparser
 import configargparse
@@ -120,7 +121,7 @@ def make_request(method,
         service,
         region,
         secret_key)
-    aws_auth_headers = task_4_add_signing_information_to_the_request(
+    new_headers = task_4_get_signed_headers_for_the_request(
         amzdate,
         payload_hash,
         algorithm,
@@ -130,7 +131,7 @@ def make_request(method,
         headers,
         access_key,
         security_token)
-    headers.update(aws_auth_headers)
+    headers.update(new_headers)
 
     return __send_request(uri, data, headers, method, verify)
 
@@ -267,7 +268,7 @@ def task_3_calculate_the_signature(
     return signature
 
 
-def task_4_add_signing_information_to_the_request(
+def task_4_get_signed_headers_for_the_request(
         amzdate,
         payload_hash,
         algorithm,
@@ -279,10 +280,15 @@ def task_4_add_signing_information_to_the_request(
         security_token):
     """
     ************* TASK 4: ADD SIGNING INFORMATION TO THE REQUEST ***********
-    The signing information can be either in a query string value or in
-    a header named Authorization. This code shows how to use a header.
-    Create authorization header and add to request headers
+    The signing information can be either in a query string value or in a header
+    named Authorization. This function shows how to use the header. It takes the
+    existing headers dict as input and returns a new headers dict with the
+    signing information added.
     """
+    # Create a copy of the headers argument so we don't modify it
+    new_headers = copy.deepcopy(headers)
+
+    # Create authorization header and add to request headers
     authorization_header = (
         algorithm + ' ' +
         'Credential=' + access_key + '/' + credential_scope + ', ' +
@@ -296,13 +302,13 @@ def task_4_add_signing_information_to_the_request(
     # signed_headers, as noted earlier. Order here is not significant.
     # Python note: The 'host' header is added automatically by the Python
     # 'requests' library.
-    headers = {
+    new_headers.update({
         'Authorization': authorization_header,
         'x-amz-date': amzdate,
         'x-amz-security-token': security_token,
         'x-amz-content-sha256': payload_hash
-    }
-    return headers
+    })
+    return new_headers
 
 
 def __normalize_query_string(query):

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -11,7 +11,6 @@ import os
 import pprint
 import sys
 import re
-import copy
 
 import configparser
 import configargparse
@@ -121,17 +120,16 @@ def make_request(method,
         service,
         region,
         secret_key)
-    new_headers = task_4_get_signed_headers_for_the_request(
+    auth_headers = task_4_build_auth_headers_for_the_request(
         amzdate,
         payload_hash,
         algorithm,
         credential_scope,
         signed_headers,
         signature,
-        headers,
         access_key,
         security_token)
-    headers.update(new_headers)
+    headers.update(auth_headers)
 
     return __send_request(uri, data, headers, method, verify)
 
@@ -268,26 +266,21 @@ def task_3_calculate_the_signature(
     return signature
 
 
-def task_4_get_signed_headers_for_the_request(
+def task_4_build_auth_headers_for_the_request(
         amzdate,
         payload_hash,
         algorithm,
         credential_scope,
         signed_headers,
         signature,
-        headers,
         access_key,
         security_token):
     """
     ************* TASK 4: ADD SIGNING INFORMATION TO THE REQUEST ***********
     The signing information can be either in a query string value or in a header
-    named Authorization. This function shows how to use the header. It takes the
-    existing headers dict as input and returns a new headers dict with the
-    signing information added.
+    named Authorization. This function shows how to use the header.  It returns
+    a headers dict with all the necessary signing headers.
     """
-    # Create a copy of the headers argument so we don't modify it
-    new_headers = copy.deepcopy(headers)
-
     # Create authorization header and add to request headers
     authorization_header = (
         algorithm + ' ' +
@@ -302,13 +295,12 @@ def task_4_get_signed_headers_for_the_request(
     # signed_headers, as noted earlier. Order here is not significant.
     # Python note: The 'host' header is added automatically by the Python
     # 'requests' library.
-    new_headers.update({
+    return {
         'Authorization': authorization_header,
         'x-amz-date': amzdate,
         'x-amz-security-token': security_token,
         'x-amz-content-sha256': payload_hash
-    })
-    return new_headers
+    }
 
 
 def __normalize_query_string(query):

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -1,3 +1,6 @@
+"""
+Awscurl implementation
+"""
 #!/usr/bin/env python
 from __future__ import print_function
 
@@ -6,24 +9,25 @@ import hashlib
 import hmac
 import os
 import pprint
-import re
 import sys
+import re
 
-import configargparse
 import configparser
+import configargparse
 import requests
+
+from .utils import sha256_hash, sha256_hash_for_binary_data, sign
 
 __author__ = 'iokulist'
 
-is_verbose = False
+IS_VERBOSE = False
 
 
 def __log(*args, **kwargs):
-    if not is_verbose:
+    if not IS_VERBOSE:
         return
-    pp = pprint.PrettyPrinter(stream=sys.stderr)
-    pp.pprint(*args, **kwargs)
-
+    stderr_pp = pprint.PrettyPrinter(stream=sys.stderr)
+    stderr_pp.pprint(*args, **kwargs)
 
 def url_path_to_dict(path):
     """http://stackoverflow.com/a/17892757/142207"""
@@ -36,20 +40,20 @@ def url_path_to_dict(path):
                r'(?P<path>/.*?)?'
                r'(\?(?P<query>.*?))?'
                r'$'
-               )
+              )
     regex = re.compile(pattern)
-    m = regex.match(path)
-    d = m.groupdict() if m is not None else None
+    url_match = regex.match(path)
+    url_dict = url_match.groupdict() if url_match is not None else None
 
-    if d['path'] is None:
-        d['path'] = '/'
+    if url_dict['path'] is None:
+        url_dict['path'] = '/'
 
-    if d['query'] is None:
-        d['query'] = ''
+    if url_dict['query'] is None:
+        url_dict['query'] = ''
 
-    return d
+    return url_dict
 
-
+# pylint: disable=too-many-arguments,too-many-locals
 def make_request(method,
                  service,
                  region,
@@ -87,48 +91,77 @@ def make_request(method,
     canonical_uri = uri_dict['path']
     port = uri_dict['port']
 
-    def sign(key, msg):
-        """
-        Key derivation functions.
-        See: http://docs.aws.amazon.com
-        /general/latest/gr/signature-v4-examples.html
-        #signature-v4-examples-python
-        """
-        return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
-
-    def get_signature_key(key, date_stamp, region_name, service_name):
-        k_date = sign(('AWS4' + key).encode('utf-8'), date_stamp)
-        k_region = sign(k_date, region_name)
-        k_service = sign(k_region, service_name)
-        k_signing = sign(k_service, 'aws4_request')
-        return k_signing
-
-    def sha256_hash(val):
-        return hashlib.sha256(val.encode('utf-8')).hexdigest()
-
-    def sha256_hash_for_binary_data(val):
-        return hashlib.sha256(val).hexdigest()
-
     # Create a date for headers and the credential string
-    t = __now()
-    amzdate = t.strftime('%Y%m%dT%H%M%SZ')
-    datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
+    current_time = __now()
+    amzdate = current_time.strftime('%Y%m%dT%H%M%SZ')
+    datestamp = current_time.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
-    # ************* TASK 1: CREATE A CANONICAL REQUEST *************
-    # http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+    canonical_request, payload_hash, signed_headers = task_1_create_a_canonical_request(
+        query,
+        headers,
+        port,
+        host,
+        amzdate,
+        method,
+        data,
+        security_token,
+        data_binary,
+        canonical_uri)
+    string_to_sign, algorithm, credential_scope = task_2_create_the_string_to_sign(
+        amzdate,
+        datestamp,
+        canonical_request,
+        service,
+        region)
+    signature = task_3_calculate_the_signature(
+        datestamp,
+        string_to_sign,
+        service,
+        region,
+        secret_key)
+    aws_auth_headers = task_4_add_signing_information_to_the_request(
+        amzdate,
+        payload_hash,
+        algorithm,
+        credential_scope,
+        signed_headers,
+        signature,
+        headers,
+        access_key,
+        security_token)
+    headers.update(aws_auth_headers)
 
-    # Step 1 is to define the verb (GET, POST, etc.)--already done.
+    return __send_request(uri, data, headers, method, verify)
 
-    # Step 2: Create canonical URI--the part of the URI from domain to query
-    # string (use '/' if no path)
-    # canonical_uri = '/'
+# pylint: disable=too-many-arguments,too-many-locals
+def task_1_create_a_canonical_request(
+        query,
+        headers,
+        port,
+        host,
+        amzdate,
+        method,
+        data,
+        security_token,
+        data_binary,
+        canonical_uri):
+    """
+    ************* TASK 1: CREATE A CANONICAL REQUEST *************
+    http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 
-    # Step 3: Create the canonical query string. In this example (a GET
-    # request),
-    # request parameters are in the query string. Query string values must
-    # be URL-encoded (space=%20). The parameters must be sorted by name.
-    # For this example, the query string is pre-formatted in the
-    # request_parameters variable.
+    Step 1 is to define the verb (GET, POST, etc.)--already done.
+
+    Step 2: Create canonical URI--the part of the URI from domain to query
+    string (use '/' if no path)
+    canonical_uri = '/'
+
+    Step 3: Create the canonical query string. In this example (a GET
+    request),
+    request parameters are in the query string. Query string values must
+    be URL-encoded (space=%20). The parameters must be sorted by name.
+    For this example, the query string is pre-formatted in the
+    request_parameters variable.
+    """
     canonical_querystring = __normalize_query_string(query)
     __log(canonical_querystring)
 
@@ -171,9 +204,19 @@ def make_request(method,
                          payload_hash)
 
     __log('\nCANONICAL REQUEST = ' + canonical_request)
-    # ************* TASK 2: CREATE THE STRING TO SIGN*************
-    # Match the algorithm to the hashing algorithm you use, either SHA-1 or
-    # SHA-256 (recommended)
+    return canonical_request, payload_hash, signed_headers
+
+def task_2_create_the_string_to_sign(
+        amzdate,
+        datestamp,
+        canonical_request,
+        service,
+        region):
+    """
+    ************* TASK 2: CREATE THE STRING TO SIGN*************
+    Match the algorithm to the hashing algorithm you use, either SHA-1 or
+    SHA-256 (recommended)
+    """
     algorithm = 'AWS4-HMAC-SHA256'
     credential_scope = (datestamp + '/' +
                         region + '/' +
@@ -185,23 +228,61 @@ def make_request(method,
                       sha256_hash(canonical_request))
 
     __log('\nSTRING_TO_SIGN = ' + string_to_sign)
-    # ************* TASK 3: CALCULATE THE SIGNATURE *************
+    return string_to_sign, algorithm, credential_scope
+
+def task_3_calculate_the_signature(
+        datestamp,
+        string_to_sign,
+        service,
+        region,
+        secret_key):
+    """
+    ************* TASK 3: CALCULATE THE SIGNATURE *************
+    """
+
+    def get_signature_key(key, date_stamp, region_name, service_name):
+        """
+        See: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+
+        In AWS Signature Version 4, instead of using your AWS access keys to sign a request, you
+        first create a signing key that is scoped to a specific region and service.  For more
+        information about signing keys, see Introduction to Signing Requests.
+        """
+        k_date = sign(('AWS4' + key).encode('utf-8'), date_stamp)
+        k_region = sign(k_date, region_name)
+        k_service = sign(k_region, service_name)
+        k_signing = sign(k_service, 'aws4_request')
+        return k_signing
+
     # Create the signing key using the function defined above.
     signing_key = get_signature_key(secret_key, datestamp, region, service)
 
     # Sign the string_to_sign using the signing_key
     encoded = string_to_sign.encode('utf-8')
     signature = hmac.new(signing_key, encoded, hashlib.sha256).hexdigest()
+    return signature
 
-    # ************* TASK 4: ADD SIGNING INFORMATION TO THE REQUEST ***********
-    # The signing information can be either in a query string value or in
-    # a header named Authorization. This code shows how to use a header.
-    # Create authorization header and add to request headers
+def task_4_add_signing_information_to_the_request(
+        amzdate,
+        payload_hash,
+        algorithm,
+        credential_scope,
+        signed_headers,
+        signature,
+        headers,
+        access_key,
+        security_token):
+    """
+    ************* TASK 4: ADD SIGNING INFORMATION TO THE REQUEST ***********
+    The signing information can be either in a query string value or in
+    a header named Authorization. This code shows how to use a header.
+    Create authorization header and add to request headers
+    """
     authorization_header = (
-            algorithm + ' ' +
-            'Credential=' + access_key + '/' + credential_scope + ', ' +
-            'SignedHeaders=' + signed_headers + ', ' +
-            'Signature=' + signature
+        algorithm + ' ' +
+        'Credential=' + access_key + '/' + credential_scope + ', ' +
+        'SignedHeaders=' + signed_headers + ', ' +
+        'Signature=' + signature
     )
 
     # The request can include any headers, but MUST include "host",
@@ -210,23 +291,23 @@ def make_request(method,
     # signed_headers, as noted earlier. Order here is not significant.
     # Python note: The 'host' header is added automatically by the Python
     # 'requests' library.
-    headers.update({
+    headers = {
         'Authorization': authorization_header,
         'x-amz-date': amzdate,
         'x-amz-security-token': security_token,
         'x-amz-content-sha256': payload_hash
-    })
+    }
+    return headers
 
-    return __send_request(uri, data, headers, method, verify)
 
 
 def __normalize_query_string(query):
-    kv = (list(map(str.strip, s.split("=")))
-          for s in query.split('&')
-          if len(s) > 0)
+    parameter_pairs = (list(map(str.strip, s.split("=")))
+                       for s in query.split('&')
+                       if len(s) > 0)
 
     normalized = '&'.join('%s=%s' % (p[0], p[1] if len(p) > 1 else '')
-                          for p in sorted(kv))
+                          for p in sorted(parameter_pairs))
     return normalized
 
 
@@ -241,19 +322,19 @@ def __send_request(uri, data, headers, method, verify):
     __log('\nBEGIN REQUEST++++++++++++++++++++++++++++++++++++')
     __log('Request URL = ' + uri)
 
-    r = requests.request(method, uri, headers=headers, data=data, verify=verify)
+    response = requests.request(method, uri, headers=headers, data=data, verify=verify)
 
     __log('\nRESPONSE++++++++++++++++++++++++++++++++++++')
-    __log('Response code: %d\n' % r.status_code)
+    __log('Response code: %d\n' % response.status_code)
 
-    return r
+    return response
 
-
+# pylint: disable=too-many-branches
 def load_aws_config(access_key, secret_key, security_token, credentials_path, profile):
     # type: (str, str, str, str, str) -> Tuple[str, str, str]
     """
-    Load aws credential configuration, by parsing credential file, then try to fall back to botocore,
-    by checking (access_key,secret_key) are not (None,None)
+    Load aws credential configuration, by parsing credential file, then try to fall back to
+    botocore, by checking (access_key,secret_key) are not (None,None)
     """
     if access_key is None or secret_key is None:
         try:
@@ -279,15 +360,15 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
 
                 break
 
-        except configparser.NoSectionError as e:
-            __log('AWS profile \'{0}\' not found'.format(e.args))
-            raise e
-        except configparser.NoOptionError as e:
-            __log('AWS profile \'{0}\' is missing \'{1}\''.format(profile, e.args))
-            raise e
-        except ValueError as e:
-            __log(e)
-            raise e
+        except configparser.NoSectionError as exception:
+            __log('AWS profile \'{0}\' not found'.format(exception.args))
+            raise exception
+        except configparser.NoOptionError as exception:
+            __log('AWS profile \'{0}\' is missing \'{1}\''.format(profile, exception.args))
+            raise exception
+        except ValueError as exception:
+            __log(exception)
+            raise exception
 
     # try to load instance credentials using botocore
     if access_key is None or secret_key is None:
@@ -308,6 +389,9 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
 
 
 def main():
+    """
+    Awscurl CLI main entry point
+    """
     # note EC2 ignores Accept header and responds in xml
     default_headers = ['Accept: application/xml',
                        'Content-Type: application/json']
@@ -334,7 +418,8 @@ def main():
                         help='Process HTTP POST data exactly as specified with '
                              'no extra processing whatsoever.', default=False)
 
-    parser.add_argument('--region', help='AWS region', default='us-east-1', env_var='AWS_DEFAULT_REGION')
+    parser.add_argument('--region', help='AWS region', default='us-east-1',
+                        env_var='AWS_DEFAULT_REGION')
     parser.add_argument('--profile', help='AWS profile', default='default', env_var='AWS_PROFILE')
     parser.add_argument('--service', help='AWS service', default='execute-api')
     parser.add_argument('--access_key', env_var='AWS_ACCESS_KEY_ID')
@@ -347,8 +432,9 @@ def main():
     parser.add_argument('uri')
 
     args = parser.parse_args()
-    global is_verbose
-    is_verbose = args.verbose
+    # pylint: disable=global-statement
+    global IS_VERBOSE
+    IS_VERBOSE = args.verbose
 
     if args.verbose:
         __log(vars(parser.parse_args()))
@@ -357,8 +443,8 @@ def main():
 
     if data is not None and data.startswith("@"):
         filename = data[1:]
-        with open(filename, "r") as f:
-            data = f.read()
+        with open(filename, "r") as post_data_file:
+            data = post_data_file.read()
 
     if args.header is None:
         args.header = default_headers
@@ -367,6 +453,7 @@ def main():
         args.session_token = args.security_token
         del args.security_token
 
+    # pylint: disable=deprecated-lambda
     headers = {k: v for (k, v) in map(lambda s: s.split(": "), args.header)}
 
     credentials_path = os.path.expanduser("~") + "/.aws/credentials"
@@ -382,24 +469,24 @@ def main():
     if args.secret_key is None:
         raise ValueError('No secret key is available')
 
-    r = make_request(args.request,
-                     args.service,
-                     args.region,
-                     args.uri,
-                     headers,
-                     data,
-                     args.access_key,
-                     args.secret_key,
-                     args.session_token,
-                     args.data_binary,
-                     args.insecure
-                     )
+    response = make_request(args.request,
+                            args.service,
+                            args.region,
+                            args.uri,
+                            headers,
+                            data,
+                            args.access_key,
+                            args.secret_key,
+                            args.session_token,
+                            args.data_binary,
+                            args.insecure
+                           )
 
     if args.include:
-        print(r.headers, end='\n\n')
-    print(r.text)
+        print(response.headers, end='\n\n')
+    print(response.text)
 
-    r.raise_for_status()
+    response.raise_for_status()
 
     return 0
 

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
 """
 Awscurl implementation
 """
-#!/usr/bin/env python
 from __future__ import print_function
 
 import datetime
@@ -29,6 +29,7 @@ def __log(*args, **kwargs):
     stderr_pp = pprint.PrettyPrinter(stream=sys.stderr)
     stderr_pp.pprint(*args, **kwargs)
 
+
 def url_path_to_dict(path):
     """http://stackoverflow.com/a/17892757/142207"""
 
@@ -39,8 +40,7 @@ def url_path_to_dict(path):
                r'(:(?P<port>\d+?))?'
                r'(?P<path>/.*?)?'
                r'(\?(?P<query>.*?))?'
-               r'$'
-              )
+               r'$')
     regex = re.compile(pattern)
     url_match = regex.match(path)
     url_dict = url_match.groupdict() if url_match is not None else None
@@ -52,6 +52,7 @@ def url_path_to_dict(path):
         url_dict['query'] = ''
 
     return url_dict
+
 
 # pylint: disable=too-many-arguments,too-many-locals
 def make_request(method,
@@ -133,6 +134,7 @@ def make_request(method,
 
     return __send_request(uri, data, headers, method, verify)
 
+
 # pylint: disable=too-many-arguments,too-many-locals
 def task_1_create_a_canonical_request(
         query,
@@ -206,6 +208,7 @@ def task_1_create_a_canonical_request(
     __log('\nCANONICAL REQUEST = ' + canonical_request)
     return canonical_request, payload_hash, signed_headers
 
+
 def task_2_create_the_string_to_sign(
         amzdate,
         datestamp,
@@ -229,6 +232,7 @@ def task_2_create_the_string_to_sign(
 
     __log('\nSTRING_TO_SIGN = ' + string_to_sign)
     return string_to_sign, algorithm, credential_scope
+
 
 def task_3_calculate_the_signature(
         datestamp,
@@ -261,6 +265,7 @@ def task_3_calculate_the_signature(
     encoded = string_to_sign.encode('utf-8')
     signature = hmac.new(signing_key, encoded, hashlib.sha256).hexdigest()
     return signature
+
 
 def task_4_add_signing_information_to_the_request(
         amzdate,
@@ -300,7 +305,6 @@ def task_4_add_signing_information_to_the_request(
     return headers
 
 
-
 def __normalize_query_string(query):
     parameter_pairs = (list(map(str.strip, s.split("=")))
                        for s in query.split('&')
@@ -328,6 +332,7 @@ def __send_request(uri, data, headers, method, verify):
     __log('Response code: %d\n' % response.status_code)
 
     return response
+
 
 # pylint: disable=too-many-branches
 def load_aws_config(access_key, secret_key, security_token, credentials_path, profile):
@@ -479,8 +484,7 @@ def main():
                             args.secret_key,
                             args.session_token,
                             args.data_binary,
-                            args.insecure
-                           )
+                            args.insecure)
 
     if args.include:
         print(response.headers, end='\n\n')

--- a/awscurl/utils.py
+++ b/awscurl/utils.py
@@ -5,17 +5,20 @@ Utilities needed during the signing process
 import hashlib
 import hmac
 
+
 def sha256_hash(val):
     """
     Sha256 hash of text data.
     """
     return hashlib.sha256(val.encode('utf-8')).hexdigest()
 
+
 def sha256_hash_for_binary_data(val):
     """
     Sha256 hash of binary data.
     """
     return hashlib.sha256(val).hexdigest()
+
 
 def sign(key, msg):
     """

--- a/awscurl/utils.py
+++ b/awscurl/utils.py
@@ -1,0 +1,27 @@
+"""
+Utilities needed during the signing process
+"""
+
+import hashlib
+import hmac
+
+def sha256_hash(val):
+    """
+    Sha256 hash of text data.
+    """
+    return hashlib.sha256(val.encode('utf-8')).hexdigest()
+
+def sha256_hash_for_binary_data(val):
+    """
+    Sha256 hash of binary data.
+    """
+    return hashlib.sha256(val).hexdigest()
+
+def sign(key, msg):
+    """
+    Key derivation functions.
+    See: http://docs.aws.amazon.com
+    /general/latest/gr/signature-v4-examples.html
+    #signature-v4-examples-python
+    """
+    return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()

--- a/tests/stages_test.py
+++ b/tests/stages_test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+"""
+Test cases for seprate header calculation stages.
+"""
+
+from unittest import TestCase
+
+from awscurl.awscurl import (
+    task_1_create_a_canonical_request,
+    task_2_create_the_string_to_sign,
+    task_3_calculate_the_signature,
+    task_4_add_signing_information_to_the_request)
+
+class TestStages(TestCase):
+    """
+    Suite to test all stages.
+    """
+    maxDiff = None
+
+    def test_task_1_create_a_canonical_request(self):
+        """
+        Test the function to create the "canonical" request to match the thing that AWS is hashing
+        on the server side.
+        """
+        canonical_request, payload_hash, signed_headers = task_1_create_a_canonical_request(
+            query="Action=DescribeInstances&Version=2013-10-15",
+            headers="{'Content-Type': 'application/json', 'Accept': 'application/xml'}",
+            port=None,
+            host="ec2.amazonaws.com",
+            amzdate="20190921T022008Z",
+            method="GET",
+            data="",
+            security_token=None,
+            data_binary=False,
+            canonical_uri="/")
+        self.assertEqual(canonical_request, "GET\n"
+                         "/\n"
+                         "Action=DescribeInstances&Version=2013-10-15\n"
+                         "host:ec2.amazonaws.com\n"
+                         "x-amz-date:20190921T022008Z\n"
+                         "\n"
+                         "host;x-amz-date\n"
+                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+        self.assertEqual(payload_hash,
+                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+        self.assertEqual(signed_headers, "host;x-amz-date")
+
+    def test_task_2_create_the_string_to_sign(self):
+        """
+        Test the next function that is creating a string in exactly the same way as AWS is on the
+        server side, to make sure our signature matches.
+        """
+        string_to_sign, algorithm, credential_scope = task_2_create_the_string_to_sign(
+            amzdate="20190921T022008Z",
+            datestamp="20190921",
+            canonical_request="GET\n"
+            "/\n"
+            "Action=DescribeInstances&Version=2013-10-15\n"
+            "host:ec2.amazonaws.com\n"
+            "x-amz-date:20190921T022008Z\n"
+            "\n"
+            "host;x-amz-date\n"
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            service="ec2",
+            region="us-east-1",
+            )
+        self.assertEqual(string_to_sign, "AWS4-HMAC-SHA256\n"
+                         "20190921T022008Z\n"
+                         "20190921/us-east-1/ec2/aws4_request\n"
+                         "4a3b77321aca7e671d4945f0b3b826112e5ca3f2a10c4357e54f518798e7c8ff")
+        self.assertEqual(algorithm, "AWS4-HMAC-SHA256")
+        self.assertEqual(credential_scope, "20190921/us-east-1/ec2/aws4_request")
+
+    def test_task_3_calculate_the_signature(self):
+        """
+        Test that we calculate the correct signature from our carefully prepared strings.
+        """
+        signature = task_3_calculate_the_signature(
+            datestamp="20190921",
+            string_to_sign="AWS4-HMAC-SHA256\n"
+            "20190921T022008Z\n"
+            "20190921/us-east-1/ec2/aws4_request\n"
+            "4a3b77321aca7e671d4945f0b3b826112e5ca3f2a10c4357e54f518798e7c8ff",
+            service="ec2",
+            region="us-east-1",
+            secret_key="dummytestsecretkey",
+            )
+        self.assertEqual(signature,
+                         "9164aea23e266890838ff6e51eea552e2ee39c63896ac61d91990f200bb16362")
+
+    def test_task_4_add_signing_information_to_the_request(self):
+        """
+        Test that we are adding the proper headers based on all our calculated information.
+        """
+        aws_auth_headers = task_4_add_signing_information_to_the_request(
+            amzdate="20190921T022008Z",
+            payload_hash="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            algorithm="AWS4-HMAC-SHA256",
+            credential_scope="20190921/us-east-1/ec2/aws4_request",
+            signed_headers="host;x-amz-date",
+            signature="9164aea23e266890838ff6e51eea552e2ee39c63896ac61d91990f200bb16362",
+            headers="{'Content-Type': 'application/json', 'Accept': 'application/xml'}",
+            access_key="AKIAIJLPLDILMJV53HCQ",
+            security_token=None,
+            )
+        self.assertEqual(
+            aws_auth_headers['x-amz-content-sha256'],
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+        self.assertEqual(
+            aws_auth_headers['x-amz-security-token'],
+            None)
+        self.assertEqual(
+            aws_auth_headers['x-amz-date'],
+            '20190921T022008Z')
+        self.assertEqual(
+            aws_auth_headers['Authorization'],
+            'AWS4-HMAC-SHA256 '
+            'Credential=AKIAIJLPLDILMJV53HCQ/20190921/us-east-1/ec2/aws4_request, '
+            'SignedHeaders=host;x-amz-date, '
+            'Signature=9164aea23e266890838ff6e51eea552e2ee39c63896ac61d91990f200bb16362')

--- a/tests/stages_test.py
+++ b/tests/stages_test.py
@@ -9,7 +9,7 @@ from awscurl.awscurl import (
     task_1_create_a_canonical_request,
     task_2_create_the_string_to_sign,
     task_3_calculate_the_signature,
-    task_4_add_signing_information_to_the_request)
+    task_4_get_signed_headers_for_the_request)
 
 class TestStages(TestCase):
     """
@@ -88,32 +88,35 @@ class TestStages(TestCase):
         self.assertEqual(signature,
                          "9164aea23e266890838ff6e51eea552e2ee39c63896ac61d91990f200bb16362")
 
-    def test_task_4_add_signing_information_to_the_request(self):
+    def test_task_4_get_signed_headers_for_the_request(self):
         """
         Test that we are adding the proper headers based on all our calculated information.
         """
-        aws_auth_headers = task_4_add_signing_information_to_the_request(
+        new_headers = task_4_get_signed_headers_for_the_request(
             amzdate="20190921T022008Z",
             payload_hash="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             algorithm="AWS4-HMAC-SHA256",
             credential_scope="20190921/us-east-1/ec2/aws4_request",
             signed_headers="host;x-amz-date",
             signature="9164aea23e266890838ff6e51eea552e2ee39c63896ac61d91990f200bb16362",
-            headers="{'Content-Type': 'application/json', 'Accept': 'application/xml'}",
+            headers={'Content-Type': 'application/json', 'Accept': 'application/xml',
+                     'Authorization': 'should override'},
             access_key="AKIAIJLPLDILMJV53HCQ",
             security_token=None,
             )
+        self.assertEqual(new_headers['Content-Type'], 'application/json')
+        self.assertEqual(new_headers['Accept'], 'application/xml')
         self.assertEqual(
-            aws_auth_headers['x-amz-content-sha256'],
+            new_headers['x-amz-content-sha256'],
             'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
         self.assertEqual(
-            aws_auth_headers['x-amz-security-token'],
+            new_headers['x-amz-security-token'],
             None)
         self.assertEqual(
-            aws_auth_headers['x-amz-date'],
+            new_headers['x-amz-date'],
             '20190921T022008Z')
         self.assertEqual(
-            aws_auth_headers['Authorization'],
+            new_headers['Authorization'],
             'AWS4-HMAC-SHA256 '
             'Credential=AKIAIJLPLDILMJV53HCQ/20190921/us-east-1/ec2/aws4_request, '
             'SignedHeaders=host;x-amz-date, '

--- a/tests/stages_test.py
+++ b/tests/stages_test.py
@@ -9,7 +9,7 @@ from awscurl.awscurl import (
     task_1_create_a_canonical_request,
     task_2_create_the_string_to_sign,
     task_3_calculate_the_signature,
-    task_4_get_signed_headers_for_the_request)
+    task_4_build_auth_headers_for_the_request)
 
 class TestStages(TestCase):
     """
@@ -88,24 +88,20 @@ class TestStages(TestCase):
         self.assertEqual(signature,
                          "9164aea23e266890838ff6e51eea552e2ee39c63896ac61d91990f200bb16362")
 
-    def test_task_4_get_signed_headers_for_the_request(self):
+    def test_task_4_build_auth_headers_for_the_request(self):
         """
         Test that we are adding the proper headers based on all our calculated information.
         """
-        new_headers = task_4_get_signed_headers_for_the_request(
+        new_headers = task_4_build_auth_headers_for_the_request(
             amzdate="20190921T022008Z",
             payload_hash="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             algorithm="AWS4-HMAC-SHA256",
             credential_scope="20190921/us-east-1/ec2/aws4_request",
             signed_headers="host;x-amz-date",
             signature="9164aea23e266890838ff6e51eea552e2ee39c63896ac61d91990f200bb16362",
-            headers={'Content-Type': 'application/json', 'Accept': 'application/xml',
-                     'Authorization': 'should override'},
             access_key="AKIAIJLPLDILMJV53HCQ",
             security_token=None,
             )
-        self.assertEqual(new_headers['Content-Type'], 'application/json')
-        self.assertEqual(new_headers['Accept'], 'application/xml')
         self.assertEqual(
             new_headers['x-amz-content-sha256'],
             'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')


### PR DESCRIPTION
This splits up the steps needed to generate the proper headers for AWS into separate functions, and adds unit tests for all the stages.  Also fixes some linter errors from pylint.

Thanks for making this project!  I want to do this in another language, and this will be a great reference.