### PR TITLE
Fix attempted relative import in non-package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ RUN set -ex \
   && pip install -r requirements.txt \
   && apk del .build-deps
 
-ENTRYPOINT ["python", "/awscurl/awscurl.py"]
-
+ENTRYPOINT ["python", "-m", "awscurl.awscurl"]


### PR DESCRIPTION
The Dockerfile is not launching the script as a package, so relative imports added in https://github.com/okigan/awscurl/commit/09d80035ac35383766a382db3718361cfa8536c7 are failing:
```
Traceback (most recent call last):
  File "/awscurl/awscurl.py", line 19, in <module>
    from .utils import sha256_hash, sha256_hash_for_binary_data, sign
ValueError: Attempted relative import in non-package
```