### PR TITLE
Make the --verbose flag imply --include

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -484,7 +484,7 @@ def main():
                             args.data_binary,
                             args.insecure)
 
-    if args.include:
+    if args.include or IS_VERBOSE:
         print(response.headers, end='\n\n')
     print(response.text)
 


### PR DESCRIPTION
Previously, `--verbose` would not print HTTP response headers, you had to
explicitly specify `--include`. This change makes the behaviour the same as
standard `curl` (where `-v` *does* print response headers).