### PR TITLE
Add encode to support non-English text data

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -131,7 +131,10 @@ def make_request(method,
         security_token)
     headers.update(auth_headers)
 
-    return __send_request(uri, data, headers, method, verify)
+    if data_binary:
+        return __send_request(uri, data, headers, method, verify)
+    else:
+        return __send_request(uri, data.encode('utf-8'), headers, method, verify)
 
 
 # pylint: disable=too-many-arguments,too-many-locals

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import base64
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -54,3 +54,47 @@ class TestMakeRequestWithTokenAndBinaryData(TestCase):
         r = make_request(**params)
 
         self.assertEqual(r.status_code, 200)
+
+class TestMakeRequestWithTokenAndEnglishData(TestCase):
+    maxDiff = None
+
+    def test_make_request(self, *args, **kvargs):
+        headers = {}
+        access_key = base64.b64decode('QUtJQUkyNkxPQU5NSlpLNVNQWUE=').decode("utf-8")
+        secret_key = base64.b64decode('ekVQbE9URjU0Mys5M0l6UlNnNEVCOEd4cjFQV2NVa1p0TERWSmY4ag==').decode("utf-8")
+        params = {'method': 'GET',
+                  'service': 's3',
+                  'region': 'us-east-1',
+                  'uri': 'https://awscurl-sample-bucket.s3.amazonaws.com/awscurl-sample-file:.txt?a=b',
+                  'headers': headers,
+                  'data': 'Test',
+                  'access_key': access_key,
+                  'secret_key': secret_key,
+                  'security_token': None,
+                  'data_binary': False}
+
+        r = make_request(**params)
+
+        self.assertEqual(r.status_code, 200)
+
+class TestMakeRequestWithTokenAndNonEnglishData(TestCase):
+    maxDiff = None
+
+    def test_make_request(self, *args, **kvargs):
+        headers = {}
+        access_key = base64.b64decode('QUtJQUkyNkxPQU5NSlpLNVNQWUE=').decode("utf-8")
+        secret_key = base64.b64decode('ekVQbE9URjU0Mys5M0l6UlNnNEVCOEd4cjFQV2NVa1p0TERWSmY4ag==').decode("utf-8")
+        params = {'method': 'GET',
+                  'service': 's3',
+                  'region': 'us-east-1',
+                  'uri': 'https://awscurl-sample-bucket.s3.amazonaws.com/awscurl-sample-file:.txt?a=b',
+                  'headers': headers,
+                  'data': 'テスト',
+                  'access_key': access_key,
+                  'secret_key': secret_key,
+                  'security_token': None,
+                  'data_binary': False}
+
+        r = make_request(**params)
+
+        self.assertEqual(r.status_code, 200)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -89,7 +89,7 @@ class TestMakeRequestWithTokenAndNonEnglishData(TestCase):
                   'region': 'us-east-1',
                   'uri': 'https://awscurl-sample-bucket.s3.amazonaws.com/awscurl-sample-file:.txt?a=b',
                   'headers': headers,
-                  'data': 'テスト',
+                  'data': u'テスト',
                   'access_key': access_key,
                   'secret_key': secret_key,
                   'security_token': None,


### PR DESCRIPTION
When I call awscurl 0.17 with non-English text data, it fails with the following UnicodeEncodeError.

```
$ awscurl -XGET --service es "${ENDPOINT}/${INDEX}/_search" -d '日本語'
Traceback (most recent call last):
  File "/usr/bin/awscurl", line 11, in <module>
    load_entry_point('awscurl==0.17', 'console_scripts', 'awscurl')()
  File "/usr/lib/python3.6/dist-packages/awscurl/awscurl.py", line 395, in main
    args.insecure
  File "/usr/lib/python3.6/dist-packages/awscurl/awscurl.py", line 220, in make_request
    return __send_request(uri, data, headers, method, verify)
  File "/usr/lib/python3.6/dist-packages/awscurl/awscurl.py", line 244, in __send_request
    r = requests.request(method, uri, headers=headers, data=data, verify=verify)
  File "/usr/lib/python3.6/dist-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python3.6/dist-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.6/dist-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3.6/dist-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/usr/lib/python3.6/dist-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/usr/lib/python3.6/dist-packages/urllib3/connectionpool.py", line 354, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib64/python3.6/http/client.py", line 1254, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1299, in _send_request
    body = _encode(body, 'body')
  File "/usr/lib64/python3.6/http/client.py", line 171, in _encode
    (name.title(), data[err.start:err.end], name)) from None
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 126-127: Body ('日本語') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```

It is because the data passed to `requests.request` method is not encoded.
Please check this pull request. Thanks.