### PR TITLE
Add encoding to print non-English responses

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -488,8 +488,8 @@ def main():
                             args.insecure)
 
     if args.include or IS_VERBOSE:
-        print(response.headers, end='\n\n')
-    print(response.text)
+        print(response.headers.encode('utf-8'), end='\n\n')
+    print(response.text.encode('utf-8'))
 
     response.raise_for_status()
 


### PR DESCRIPTION
I found another encoding problem.

When I call awscurl 0.17 and its response includes non-English text data, it fails with the following UnicodeEncodeError.

```
Traceback (most recent call last):
  File "/usr/local/bin/awscurl", line 11, in <module>
    load_entry_point('awscurl==0.17', 'console_scripts', 'awscurl')()
  File "/usr/local/lib/python2.7/site-packages/awscurl/awscurl.py", line 403, in main
    print(r.text)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 333-334: ordinal not in range(128)
```

It is because the response data is not encoded too. Please review it.

In this case, I could not add any proper unit tests because the lines are in main method.
If some kind of tests are needed, please let me know. Thanks.