### PR TITLE
Host header only checked if provided as lowercase

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -460,7 +460,7 @@ def inner_main(argv):
         del args.security_token
 
     # pylint: disable=deprecated-lambda
-    headers = {k: v for (k, v) in map(lambda s: s.split(": "), args.header)}
+    headers = {k.lower(): v for (k, v) in map(lambda s: s.split(": "), args.header)}
 
     credentials_path = os.path.expanduser("~") + "/.aws/credentials"
     args.access_key, args.secret_key, args.session_token = load_aws_config(args.access_key,


### PR DESCRIPTION
When building the signing request, we are only checking for 'host' -> https://github.com/okigan/awscurl/blob/master/awscurl/awscurl.py#L174

If, for example, I specify --header 'Host: www.google.com', this is completely disregarded, causing many headaches as to why I couldn't auth! Even though HTTP headers are to be considered case-insensitive as per RFC it is known that some servers require the 'host' header have a capitalised first letter.

This change ensures we store the header type as a lower case string.