### PR TITLE
Support for binary files

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -449,7 +449,8 @@ def inner_main(argv):
 
     if data is not None and data.startswith("@"):
         filename = data[1:]
-        with open(filename, "r") as post_data_file:
+        read_mode = "rb" if args.data_binary else "r"
+        with open(filename, read_mode) as post_data_file:
             data = post_data_file.read()
 
     if args.header is None:


### PR DESCRIPTION
I wasn't able to send a binary file without the above changes
Stacktrace:
```
Traceback (most recent call last):
  File "/Users/dpichler/anaconda2/envs/voice-cloning-updated/bin/awscurl", line 8, in <module>
    sys.exit(main())
  File "/Users/dpichler/anaconda2/envs/voice-cloning-updated/lib/python3.6/site-packages/awscurl/awscurl.py", line 501, in main
    inner_main(sys.argv[1:])
  File "/Users/dpichler/anaconda2/envs/voice-cloning-updated/lib/python3.6/site-packages/awscurl/awscurl.py", line 454, in inner_main
    data = post_data_file.read()
  File "/Users/dpichler/anaconda2/envs/voice-cloning-updated/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa2 in position 4: invalid start byte
```