### PR TITLE
Execute credential process to get temporary credentials.

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -7,10 +7,11 @@ from __future__ import print_function
 import datetime
 import hashlib
 import hmac
+import json
 import os
 import pprint
-import sys
 import re
+import sys
 
 import configparser
 import configargparse
@@ -351,6 +352,18 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
             config.read(credentials_path)
 
             while True:
+                if access_key is None and config.has_option(profile, "credential_process"):
+                    cmd = config.get(profile, "credential_process")
+                    stream = os.popen(cmd)
+                    json_profile = stream.read()
+                    process_profile = json.loads(json_profile)
+
+                    access_key = process_profile["AccessKeyId"]
+                    secret_key = process_profile["SecretAccessKey"]
+                    security_token = process_profile["SessionToken"]
+                else:
+                    break
+
                 if access_key is None and config.has_option(profile, "aws_access_key_id"):
                     access_key = config.get(profile, "aws_access_key_id")
                 else:


### PR DESCRIPTION
At work we use `credential_process` inside of ~/.aws/credientials, with a profile for each app/env combo so that we don't have to manually manage our AWS credentials. This adds support for using this directive: Get the command, execute in subshell to obtain JSON, parse json, and extract access key, secret, and session.

Follows https://github.com/aws/aws-cli/blob/ecd654bb665a29246496e6dcac33e24a60d6cf7a/awscli/topics/config-vars.rst#sourcing-credentials-from-external-processes