### PR TITLE
Fix: Booleans verify and insecure are not interchangable.

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -485,7 +485,7 @@ def inner_main(argv):
                             args.secret_key,
                             args.session_token,
                             args.data_binary,
-                            args.insecure)
+                            verify=not args.insecure)
 
     if args.include or IS_VERBOSE:
         print(response.headers, end='\n\n')

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -416,9 +416,8 @@ def inner_main(argv):
                         default='GET')
     parser.add_argument('-d', '--data', help='HTTP POST data', default='')
     parser.add_argument('-H', '--header', help='HTTP header', action='append')
-    parser.add_argument('-k', '--insecure', action='store_false',
-                        help='This option allows awscurl to proceed and operate even for server '
-                             'connections otherwise considered insecure')
+    parser.add_argument('-k', '--insecure', action='store_true', default=False,
+                        help='Allow insecure server connections when using SSL')
 
     parser.add_argument('--data-binary', action='store_true',
                         help='Process HTTP POST data exactly as specified with '


### PR DESCRIPTION
The `--help` indicates that the `-k --insecure` flag is by default True, however this was not actually the case.

The confusion is that the `--help` calls the flag `--insecure`, but this flag is passed to the `make_request` method where the parameter is named `verify`. Naturally verify should be equal to not insecure, and this change implements that.

This change flips the `--insecure` flag at the `make_request` method call so that its value is in line with what the method expects, as well as keeping the semantics consistent wherever `verify` or `insecure` is mentioned.