### PR TITLE
Revert "Use botocore to support SSO profiles (#116)"

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -389,7 +389,7 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
 
         if botocore:
             import botocore.session
-            session = botocore.session.Session(profile=profile)
+            session = botocore.session.get_session()
             cred = session.get_credentials()
             access_key, secret_key, security_token = cred.access_key, cred.secret_key, cred.token
 


### PR DESCRIPTION
This reverts commit c51bf9a849b669135812941cc92dd8591eb1ee39.