### PR TITLE
Allow credential process to be used for profiles

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -404,8 +404,8 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
             botocore = None
 
         if botocore:
-            import botocore.session
-            session = botocore.session.get_session()
+            from botocore.session import Session
+            session = Session(profile=profile)
             cred = session.get_credentials()
             access_key, secret_key, security_token = cred.access_key, cred.secret_key, cred.token
 


### PR DESCRIPTION
Currently, when using a credential_process, I am unable to make calls successfully as there are no credentials in `~/.aws/credentials`. This allows the usage of credential_process for the specified profile.