### PR TITLE
Fixes #152: Set script exit code based on request success

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -531,12 +531,12 @@ def inner_main(argv):
     elif IS_VERBOSE:
         pprint.PrettyPrinter(stream=sys.stderr).pprint(response.headers)
         pprint.PrettyPrinter(stream=sys.stderr).pprint('')
-        
+
     print(response.text)
 
-    response.raise_for_status()
+    exit_code = 0 if response.ok else 1
 
-    return 0
+    return exit_code
 
 
 def main():

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -21,7 +21,6 @@ print(f'sys.path2={sys.path}')
 
 import pytest
 from mock import patch
-from requests import HTTPError
 
 from awscurl.awscurl import make_request, inner_main
 
@@ -123,5 +122,8 @@ class TestMakeRequestWithTokenAndNonEnglishData(TestCase):
 class TestInnerMainMethod(TestCase):
     maxDiff = None
 
-    with pytest.raises(HTTPError):
-        inner_main(['--verbose', '--service', 's3', 'https://awscurl-sample-bucket.s3.amazonaws.com'])
+    def test_exit_code(self, *args, **kwargs):
+        self.assertEqual(
+            inner_main(['--verbose', '--service', 's3', 'https://awscurl-sample-bucket.s3.amazonaws.com']),
+            1
+        )


### PR DESCRIPTION
This small change fixes #152 and ensures that the traceback from `response.raise_for_status()` is not included in the program's output.

Although the property `response.ok` uses `raise_for_status()` under the hood, the raised exception `HTTPError` is caught and a boolean value is returned.

Using the boolean value from `ok` we can determine whether to set a successful or unsuccessful exit code.