### PR TITLE
Use profile if set, remove default

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -464,7 +464,7 @@ def inner_main(argv):
 
     parser.add_argument('--region', help='AWS region', default='us-east-1',
                         env_var='AWS_DEFAULT_REGION')
-    parser.add_argument('--profile', help='AWS profile', default='default', env_var='AWS_PROFILE')
+    parser.add_argument('--profile', help='AWS profile', env_var='AWS_PROFILE')
     parser.add_argument('--service', help='AWS service', default='execute-api')
     parser.add_argument('--access_key', env_var='AWS_ACCESS_KEY_ID')
     parser.add_argument('--secret_key', env_var='AWS_SECRET_ACCESS_KEY')

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -423,7 +423,10 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
 
         if botocore:
             import botocore.session
-            session = botocore.session.get_session()
+            if profile:
+                session = botocore.session.Session(profile=profile)
+            else:
+                session = botocore.session.get_session()
             cred = session.get_credentials()
             access_key, secret_key, security_token = cred.access_key, cred.secret_key, cred.token
 


### PR DESCRIPTION
Tries to address #44 without breaking access in ec2 (#163).
This reintroduces code added with #146 while hoping to avoid breaking other workflows.

I've verified that the cloudshell reproduction shown in #163 does not break with this addition. The removal of the default value for --profile might still carry some risk.