### PR TITLE
Lowercase hostname when generating canonical headers

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -197,7 +197,7 @@ def task_1_create_a_canonical_request(
     # Step 4: Create the canonical headers and signed headers. Header names
     # and value must be trimmed and lowercase, and sorted in ASCII order.
     # Note that there is a trailing \n.
-    canonical_headers = ('host:' + fullhost + '\n' +
+    canonical_headers = ('host:' + fullhost.lower() + '\n' +
                          'x-amz-date:' + amzdate + '\n')
 
     if security_token:


### PR DESCRIPTION
If we force the hostname to lower case when generating the canonical headers for the request signature, as suggested by the "must be trimmed and lowercase" comment above, we don't generate a confusing signature error when the user types the hostname in mixed case.

This fixes https://github.com/okigan/awscurl/issues/186.