### PR TITLE
bugfix(args): normalize empty credentials

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -431,6 +431,13 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
     return access_key, secret_key, security_token
 
 
+def normalize_args(args):
+    if args.access_key == "":
+        args.access_key = None
+    if args.secret_key == "":
+        args.secret_key = None
+
+
 def inner_main(argv):
     """
     Awscurl CLI main entry point
@@ -477,6 +484,7 @@ def inner_main(argv):
     parser.add_argument('uri')
 
     args = parser.parse_args(argv)
+    normalize_args(args)
     # pylint: disable=global-statement
     global IS_VERBOSE
     IS_VERBOSE = args.verbose

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -436,6 +436,10 @@ def normalize_args(args):
         args.access_key = None
     if args.secret_key == "":
         args.secret_key = None
+    if args.security_token == "":
+        args.security_token = None
+    if args.session_token == "":
+        args.session_token = None
 
 
 def inner_main(argv):

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -125,3 +125,12 @@ class TestInnerMainMethod(TestCase):
             inner_main(['--verbose', '--service', 's3', 'https://awscurl-sample-bucket.s3.amazonaws.com']),
             1
         )
+
+class TestInnerMainMethodEmptyCredentials(TestCase):
+    maxDiff = None
+
+    def test_exit_code(self, *args, **kwargs):
+        self.assertEqual(
+            inner_main(['--verbose', '--access_key', '', '--secret_key', '', '--service', 's3', 'https://awscurl-sample-bucket.s3.amazonaws.com']),
+            1
+        )

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -131,6 +131,7 @@ class TestInnerMainMethodEmptyCredentials(TestCase):
 
     def test_exit_code(self, *args, **kwargs):
         self.assertEqual(
-            inner_main(['--verbose', '--access_key', '', '--secret_key', '', '--service', 's3', 'https://awscurl-sample-bucket.s3.amazonaws.com']),
+            inner_main(['--verbose', '--access_key', '', '--secret_key', '', '--session_token', '', '--service', 's3',
+                        'https://awscurl-sample-bucket.s3.amazonaws.com']),
             1
         )


### PR DESCRIPTION
Validate if credentials are empty string set them to None.
This allows to keep checking for other credentials sources when the input is an empty string.
Common case is having an environment variable set as empty text.