### PR TITLE
fix: exit code not passed to sys.exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ docker pull ghcr.io/okigan/awscurl
 ## Options
 
 ```sh
-usage: __main__.py [-h] [-v] [-i] [-X REQUEST] [-d DATA] [-H HEADER] [-k] [--data-binary] [--region REGION] [--profile PROFILE] [--service SERVICE]
+usage: __main__.py [-h] [-v] [-i] [-X REQUEST] [-d DATA] [-H HEADER] [-k] [--fail-with-body] [--data-binary] [--region REGION] [--profile PROFILE] [--service SERVICE]
                    [--access_key ACCESS_KEY] [--secret_key SECRET_KEY] [--security_token SECURITY_TOKEN] [--session_token SESSION_TOKEN] [-L] [-o <file>]
                    uri
 
@@ -145,6 +145,7 @@ options:
   -H HEADER, --header HEADER
                         HTTP header (default: None)
   -k, --insecure        Allow insecure server connections when using SSL (default: False)
+  --fail-with-body      Fail on HTTP errors but save the body (default: False)
   --data-binary         Process HTTP POST data exactly as specified with no extra processing whatsoever. (default: False)
   --region REGION       AWS region [env var: AWS_DEFAULT_REGION] (default: us-east-1)
   --profile PROFILE     AWS profile [env var: AWS_PROFILE] (default: default)

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -475,6 +475,7 @@ def inner_main(argv):
     parser.add_argument('-H', '--header', help='HTTP header', action='append')
     parser.add_argument('-k', '--insecure', action='store_true', default=False,
                         help='Allow insecure server connections when using SSL')
+    parser.add_argument('--fail-with-body', action='store_true', help='Fail on HTTP errors but save the body', default=False)
 
     parser.add_argument('--data-binary', action='store_true',
                         help='Process HTTP POST data exactly as specified with '
@@ -564,7 +565,7 @@ def inner_main(argv):
         with open(filename, file_mode) as f:
             f.write(response.content)
 
-    exit_code = 0 if response.ok else 1
+    exit_code = 0 if response.ok or not args.fail_with_body else 22
 
     return exit_code
 

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -570,7 +570,7 @@ def inner_main(argv):
 
 
 def main():
-    inner_main(sys.argv[1:])
+    return inner_main(sys.argv[1:])
 
 
 if __name__ == '__main__':

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -120,18 +120,31 @@ class TestMakeRequestWithTokenAndNonEnglishData(TestCase):
 class TestInnerMainMethod(TestCase):
     maxDiff = None
 
-    def test_exit_code(self, *args, **kwargs):
+    def test_exit_code_without_fail_option(self, *args, **kwargs):
         self.assertEqual(
             inner_main(['--verbose', '--service', 's3', 'https://awscurl-sample-bucket.s3.amazonaws.com']),
-            1
+            0
+        )
+
+    def test_exit_code_with_fail_option(self, *args, **kwargs):
+        self.assertEqual(
+            inner_main(['--verbose', '--fail-with-body', '--service', 's3', 'https://awscurl-sample-bucket.s3.amazonaws.com']),
+            22
         )
 
 class TestInnerMainMethodEmptyCredentials(TestCase):
     maxDiff = None
 
-    def test_exit_code(self, *args, **kwargs):
+    def test_exit_code_without_fail_option(self, *args, **kwargs):
         self.assertEqual(
             inner_main(['--verbose', '--access_key', '', '--secret_key', '', '--session_token', '', '--service', 's3',
                         'https://awscurl-sample-bucket.s3.amazonaws.com']),
-            1
+            0
+        )
+
+    def test_exit_code_with_fail_option(self, *args, **kwargs):
+        self.assertEqual(
+            inner_main(['--verbose', '--fail-with-body', '--access_key', '', '--secret_key', '', '--session_token', '', '--service', 's3',
+                        'https://awscurl-sample-bucket.s3.amazonaws.com']),
+            22
         )


### PR DESCRIPTION
fixes: #208 

tested locally

```shell
$ python3 -m awscurl --service lambda https://<my-function-url>.lambda-url.ap-southeast-2.on.aws/
{"data":"Hello from Lambda!"}
$ echo $?
1
```