### PR TITLE
fix: output option errors with text response

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -560,9 +560,12 @@ def inner_main(argv):
 
     if args.output:
         filename = args.output
-        file_mode = "wb" if args.data_binary else "w"
-        with open(filename, file_mode) as f:
-            f.write(response.content)
+        if args.data_binary:
+            with open(filename, "wb") as f:
+                f.write(response.content)
+        else:
+            with open(filename, "w") as f:
+                f.write(response.text)
 
     exit_code = 0 if response.ok else 1
 


### PR DESCRIPTION
fixes: #210 

tested locally

```shell
$ python3 -m awscurl --service lambda https://ramopiru4w634m75ht2jtq7fea0ibyps.lambda-url.ap-southeast-2.on.aws/ -o out.json
{"data":"Hello from Lambda!"}

$ cat out.json 
{"data":"Hello from Lambda!"}
```