### PR TITLE
feat: Support sigv4a

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setup(
         'configargparse',
         'configparser',
         'urllib3',
-        'botocore',
+        "boto3",
+        "botocore",
+        "awscrt"
     ],
     extras_require={
         'awslibs': []


### PR DESCRIPTION
** Problem **

This library is a key tool in dev testing aws services particular self hosted api gateway instances as it has strong integration with api gateway.

However there can be problems in using this in high availability multi-region solutions built on top of AWS due to the fact that in these situations it is not always easy to determine what the region you will be talking to will be at request signing time.

Luckily AWS introduced sigv4a to solve this problem and allow flexibilty, this Pull Request impliments sigv4a for awscurl

** Solution **

This is a minimal proposed fix that pulls in logic written in amazon and vended out to do most of the heavy lifting. pulling a dependency on awscrt for the credential logic.

This is largely based off of the example for sigv4a from aws: [here](https://github.com/aws-samples/sigv4a-signing-examples/tree/main/python).

** Testing **

I hit an endpoint for an API Gateway instance in us-west-2, below was the outcome

```
docker run --rm -ti -v "$HOME/.aws:/root/.aws" -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SECURITY_TOKEN -e AWS_PROFILE -e AWS_REGION awscurl  "https://my.apigateway.instance.dev" --region '*'
{"redacted": "test data :D"}
```