### PR TITLE
Respect 'profile' name when botocore is used to fetch credentials

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -434,6 +434,8 @@ def load_aws_config(access_key, secret_key, security_token, credentials_path, pr
         if botocore:
             import botocore.session
             session = botocore.session.get_session()
+            if profile is not None:
+                session.set_config_variable('profile', profile)
             cred = session.get_credentials()
             access_key, secret_key, security_token = cred.access_key, cred.secret_key, cred.token
 

--- a/tests/load_aws_config_test.py
+++ b/tests/load_aws_config_test.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
 
-
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest import TestCase
+
+import mock
 
 from awscurl.awscurl import load_aws_config
 
-__author__ = 'iokulist'
+__author__ = "iokulist"
 
 
 class Test__load_aws_config(TestCase):
@@ -34,3 +39,35 @@ class Test__load_aws_config(TestCase):
         #                                                    "default")
         #
         # self.assertEquals([access_key, secret_access, token], ['aaa', None, 'ttt'])
+
+    def test_credential_process(self):
+        expire_dt = datetime.now(tz=timezone.utc) + timedelta(seconds=10)
+        test_creds = {
+            "Version": 1,
+            "AccessKeyId": "testAccessKeyId",
+            "SecretAccessKey": "testSecretAccessKey",
+            "SessionToken": "testSessionToken",
+            #
+            "Expiration": expire_dt.isoformat(timespec="seconds"),
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            creds_str = json.dumps(test_creds)
+            creds_file = Path(tmp_dir) / "config"
+            with creds_file.open("w") as fp:
+                fp.write(f"""
+                [profile tester]
+                credential_process=echo '{creds_str}'
+                """)
+            with mock.patch.dict("os.environ", {"AWS_CONFIG_FILE": str(creds_file)}):
+                access_key, secret_access, token = load_aws_config(
+                    None, None, None, "./tests/data/credentials", "tester"
+                )
+                self.assertEqual(
+                    [access_key, secret_access, token],
+                    [
+                        test_creds["AccessKeyId"],
+                        test_creds["SecretAccessKey"],
+                        test_creds["SessionToken"],
+                    ],
+                )


### PR DESCRIPTION
When `awscurl` is invoked with a profile name, and that profile is configured to use `credential_process`, `awscurl` was ignoring the profile name.

This change sets the profile name for the session in the same way the [AWS CLI does](https://github.com/aws/aws-cli/blob/436f74b4b85a6d16621deffff64877b9a865c1e9/awscli/clidriver.py#L285C26-L285C45).