### PR TITLE
Fix query parameter encoding

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -16,7 +16,7 @@ from botocore import crt, awsrequest
 from botocore.credentials import Credentials
 from typing import Dict
 import urllib
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 import configparser
 import configargparse
@@ -364,7 +364,7 @@ def get_sigv4a_headers(service, region, method, url, access_key, secret_key, sec
 
 
 def __normalize_query_string(query):
-    parameter_pairs = (list(map(str.strip, s.split("=")))
+    parameter_pairs = (list(map(str.strip, s.split("=", 1)))
                        for s in query.split('&')
                        if len(s) > 0)
 
@@ -381,9 +381,9 @@ def aws_url_encode(text):
     - Percent-encode all other characters with %XY, where X and Y are hexadecimal characters (0-9 and uppercase A-F).
       For example, the space character must be encoded as %20 (not using '+', as some encoding schemes do) and
       extended UTF-8 characters must be in the form %XY%ZA%BC.
-    - Double-encode any equals (=) characters in parameter values.
+    - Percent-encode all other characters including equals (=).
     """
-    return quote(text, safe='~=').replace('=', '==')
+    return quote(unquote(text), safe='~')
 
 
 def __now():

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -16,7 +16,7 @@ from botocore import crt, awsrequest
 from botocore.credentials import Credentials
 from typing import Dict
 import urllib
-from urllib.parse import quote, unquote
+from urllib.parse import quote_from_bytes, unquote_to_bytes
 
 import configparser
 import configargparse
@@ -383,7 +383,7 @@ def aws_url_encode(text):
       extended UTF-8 characters must be in the form %XY%ZA%BC.
     - Percent-encode all other characters including equals (=).
     """
-    return quote(unquote(text), safe='~')
+    return quote_from_bytes(unquote_to_bytes(text), safe='~')
 
 
 def __now():

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -17,7 +17,7 @@ from botocore import crt, awsrequest
 from botocore.credentials import Credentials
 from typing import Dict
 import urllib
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 from urllib3.util.ssl_ import create_urllib3_context
 
 import configparser
@@ -379,7 +379,7 @@ def get_sigv4a_headers(service, region, method, url, access_key, secret_key, sec
 
 
 def __normalize_query_string(query):
-    parameter_pairs = (list(map(str.strip, s.split("=")))
+    parameter_pairs = (list(map(str.strip, s.split("=", 1)))
                        for s in query.split('&')
                        if len(s) > 0)
 
@@ -396,9 +396,9 @@ def aws_url_encode(text):
     - Percent-encode all other characters with %XY, where X and Y are hexadecimal characters (0-9 and uppercase A-F).
       For example, the space character must be encoded as %20 (not using '+', as some encoding schemes do) and
       extended UTF-8 characters must be in the form %XY%ZA%BC.
-    - Double-encode any equals (=) characters in parameter values.
+    - Percent-encode all other characters including equals (=).
     """
-    return quote(text, safe='~=').replace('=', '==')
+    return quote(unquote(text), safe='~')
 
 
 def __now():

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -17,7 +17,7 @@ from botocore import crt, awsrequest
 from botocore.credentials import Credentials
 from typing import Dict
 import urllib
-from urllib.parse import quote, unquote
+from urllib.parse import quote_from_bytes, unquote_to_bytes
 from urllib3.util.ssl_ import create_urllib3_context
 
 import configparser
@@ -398,7 +398,7 @@ def aws_url_encode(text):
       extended UTF-8 characters must be in the form %XY%ZA%BC.
     - Percent-encode all other characters including equals (=).
     """
-    return quote(unquote(text), safe='~')
+    return quote_from_bytes(unquote_to_bytes(text), safe='~')
 
 
 def __now():

--- a/tests/stages_test.py
+++ b/tests/stages_test.py
@@ -79,6 +79,32 @@ class TestStages(TestCase):
                          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
         self.assertEqual(signed_headers, "content-type;host;x-amz-content-sha256;x-amz-date")
 
+    def test_task_1_create_a_canonical_request_equals_in_value(self):
+        """
+        Test that query values containing '=' (e.g. base64 padding) and
+        pre-encoded characters are handled correctly without double-encoding.
+        """
+        canonical_request, payload_hash, signed_headers = task_1_create_a_canonical_request(
+            query="token=abc==&filter=%7Bstatus%3D%222xx%22%7D&plain=hello%20world",
+            headers={},
+            port=None,
+            host="example.amazonaws.com",
+            amzdate="20190921T022008Z",
+            method="GET",
+            data="",
+            security_token=None,
+            data_binary=False,
+            canonical_uri="/")
+        self.assertEqual(canonical_request, "GET\n"
+                         "/\n"
+                         "filter=%7Bstatus%3D%222xx%22%7D&plain=hello%20world&token=abc%3D%3D\n"
+                         "host:example.amazonaws.com\n"
+                         "x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n"
+                         "x-amz-date:20190921T022008Z\n"
+                         "\n"
+                         "host;x-amz-content-sha256;x-amz-date\n"
+                         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+
     def test_task_1_header_with_amz_substring_not_signed(self):
         """
         Test that headers containing 'x-amz-' as a substring (not prefix) are not

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -395,6 +395,11 @@ class TestAwsUrlEncode(TestCase):
         self.assertEqual(aws_url_encode("group%20by"), "group%20by")
         self.assertEqual(aws_url_encode("%7Bstatus%3D%222xx%22%7D"), "%7Bstatus%3D%222xx%22%7D")
 
+    def test_aws_url_encode_non_utf8(self):
+        """Non-UTF8 percent-encoded bytes like %FF must be preserved."""
+        self.assertEqual(aws_url_encode("%FF"), "%FF")
+        self.assertEqual(aws_url_encode("a%FFb"), "a%FFb")
+
     pass
 
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -387,8 +387,13 @@ class TestAwsUrlEncode(TestCase):
         self.assertEqual(aws_url_encode(""), "")
         self.assertEqual(aws_url_encode("AZaz09-_.~"), "AZaz09-_.~")
         self.assertEqual(aws_url_encode(" /:@[`{"), "%20%2F%3A%40%5B%60%7B")
-        self.assertEqual(aws_url_encode("a=,=b"), "a==%2C==b")
+        self.assertEqual(aws_url_encode("a=,=b"), "a%3D%2C%3Db")
         self.assertEqual(aws_url_encode("\u0394-\u30a1"), "%CE%94-%E3%82%A1")
+
+    def test_aws_url_encode_pre_encoded(self):
+        """Pre-encoded input should not be double-encoded."""
+        self.assertEqual(aws_url_encode("group%20by"), "group%20by")
+        self.assertEqual(aws_url_encode("%7Bstatus%3D%222xx%22%7D"), "%7Bstatus%3D%222xx%22%7D")
 
     pass
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -454,6 +454,11 @@ class TestAwsUrlEncode(TestCase):
         self.assertEqual(aws_url_encode("group%20by"), "group%20by")
         self.assertEqual(aws_url_encode("%7Bstatus%3D%222xx%22%7D"), "%7Bstatus%3D%222xx%22%7D")
 
+    def test_aws_url_encode_non_utf8(self):
+        """Non-UTF8 percent-encoded bytes like %FF must be preserved."""
+        self.assertEqual(aws_url_encode("%FF"), "%FF")
+        self.assertEqual(aws_url_encode("a%FFb"), "a%FFb")
+
     pass
 
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -446,8 +446,13 @@ class TestAwsUrlEncode(TestCase):
         self.assertEqual(aws_url_encode(""), "")
         self.assertEqual(aws_url_encode("AZaz09-_.~"), "AZaz09-_.~")
         self.assertEqual(aws_url_encode(" /:@[`{"), "%20%2F%3A%40%5B%60%7B")
-        self.assertEqual(aws_url_encode("a=,=b"), "a==%2C==b")
+        self.assertEqual(aws_url_encode("a=,=b"), "a%3D%2C%3Db")
         self.assertEqual(aws_url_encode("\u0394-\u30a1"), "%CE%94-%E3%82%A1")
+
+    def test_aws_url_encode_pre_encoded(self):
+        """Pre-encoded input should not be double-encoded."""
+        self.assertEqual(aws_url_encode("group%20by"), "group%20by")
+        self.assertEqual(aws_url_encode("%7Bstatus%3D%222xx%22%7D"), "%7Bstatus%3D%222xx%22%7D")
 
     pass
 


### PR DESCRIPTION
## Fix query parameter encoding

Fixes three related bugs in how query parameters are encoded for AWS SigV4 signing:

### 1. Equals signs in query values split incorrectly
`__normalize_query_string` used `s.split("=")` which broke values containing `=` (e.g. base64-encoded values). Changed to `s.split("=", 1)`.

### 2. Non-standard double-encoding of equals signs
`aws_url_encode` kept `=` as a safe character then replaced it with `==`, which is not standard URL encoding. Now properly percent-encodes `=` as `%3D`.

### 3. Double-encoding of pre-encoded URLs
URLs that already contain percent-encoded characters (e.g. `%20`, `%7B`) were being double-encoded (e.g. `%20` becoming `%2520`). Now applies `unquote()` before `quote()` to normalize first.

### Issues resolved
- Fixes #169
- Fixes #216
- Supersedes #171

### Testing
- All 22 existing unit tests pass
- Added new test for pre-encoded URL handling
- Updated existing `aws_url_encode` test for correct encoding behavior
