### PR TITLE
Add --tls-min and --tls-max options for TLS version control

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -405,6 +405,31 @@ def __now():
     return datetime.datetime.utcnow()
 
 
+class _TLSAdapter(HTTPAdapter):
+    def __init__(self, tls_min=None, tls_max=None, verify=True, **kwargs):
+        self._tls_min = tls_min
+        self._tls_max = tls_max
+        self._verify = verify
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        ctx = create_urllib3_context()
+
+        tls_min_ver = TLS_VERSIONS.get(self._tls_min)
+        tls_max_ver = TLS_VERSIONS.get(self._tls_max)
+
+        if tls_min_ver is not None:
+            ctx.minimum_version = tls_min_ver
+        if tls_max_ver is not None:
+            ctx.maximum_version = tls_max_ver
+
+        if not self._verify:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        kwargs['ssl_context'] = ctx
+        super().init_poolmanager(*args, **kwargs)
+
+
 def __send_request(uri, data, headers, method, verify, allow_redirects, tls_min, tls_max):
     __log('\nHEADERS++++++++++++++++++++++++++++++++++++')
     __log(headers)
@@ -416,27 +441,15 @@ def __send_request(uri, data, headers, method, verify, allow_redirects, tls_min,
         import urllib3
         urllib3.disable_warnings()
 
-    class TLSAdapter(HTTPAdapter):
-        def init_poolmanager(self, *args, **kwargs):
-            ctx = create_urllib3_context()
+    if tls_min is not None and tls_max is not None:
+        min_ver = TLS_VERSIONS[tls_min]
+        max_ver = TLS_VERSIONS[tls_max]
+        if min_ver > max_ver:
+            raise ValueError('--tls-min ({}) must not exceed --tls-max ({})'.format(tls_min, tls_max))
 
-            tls_min_ver = TLS_VERSIONS.get(tls_min)
-            tls_max_ver = TLS_VERSIONS.get(tls_max)
-
-            if tls_min_ver is not None:
-                ctx.minimum_version = tls_min_ver
-            if tls_max_ver is not None:
-                ctx.maximum_version = tls_max_ver
-
-            if not verify:
-                ctx.check_hostname = False
-                ctx.verify_mode = ssl.CERT_NONE
-            kwargs['ssl_context'] = ctx
-            super().init_poolmanager(*args, **kwargs)
-
-    session = requests.Session()
-    session.mount('https://', TLSAdapter())
-    response = session.request(method, uri, headers=headers, data=data, verify=verify, allow_redirects=allow_redirects)
+    with requests.Session() as session:
+        session.mount('https://', _TLSAdapter(tls_min=tls_min, tls_max=tls_max, verify=verify))
+        response = session.request(method, uri, headers=headers, data=data, verify=verify, allow_redirects=allow_redirects)
 
     __log('\nRESPONSE++++++++++++++++++++++++++++++++++++')
     __log('Response code: %d\n' % response.status_code)
@@ -576,8 +589,8 @@ def inner_main(argv):
     parser.add_argument('-L', '--location', action='store_true', default=False,
                         help="Follow redirects")
     parser.add_argument('-o', '--output', metavar="<file>", help='Write to file instead of stdout', default='')
-    parser.add_argument('--tls_min', help='Set minimum allowed TLS version', choices=TLS_VERSIONS.keys())
-    parser.add_argument('--tls_max', help='Set maximum allowed TLS version', choices=TLS_VERSIONS.keys())
+    parser.add_argument('--tls-min', help='Set minimum allowed TLS version', choices=TLS_VERSIONS.keys())
+    parser.add_argument('--tls-max', help='Set maximum allowed TLS version', choices=TLS_VERSIONS.keys())
 
     parser.add_argument('uri')
 

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -9,6 +9,7 @@ import hashlib
 import hmac
 import os
 import pprint
+import ssl
 import sys
 import re
 
@@ -17,10 +18,12 @@ from botocore.credentials import Credentials
 from typing import Dict
 import urllib
 from urllib.parse import quote
+from urllib3.util.ssl_ import create_urllib3_context
 
 import configparser
 import configargparse
 import requests
+from requests.adapters import HTTPAdapter
 from requests.structures import CaseInsensitiveDict
 
 
@@ -29,6 +32,14 @@ from .utils import sha256_hash, sha256_hash_for_binary_data, sign
 __author__ = 'iokulist'
 
 IS_VERBOSE = False
+
+
+TLS_VERSIONS = {
+    "1.0": ssl.TLSVersion.TLSv1,
+    "1.1": ssl.TLSVersion.TLSv1_1,
+    "1.2": ssl.TLSVersion.TLSv1_2,
+    "1.3": ssl.TLSVersion.TLSv1_3,
+}
 
 
 def __log(*args, **kwargs):
@@ -74,7 +85,9 @@ def make_request(method,
                  security_token,
                  data_binary,
                  verify=True,
-                 allow_redirects=False):
+                 allow_redirects=False,
+                 tls_min=None,
+                 tls_max=None):
     """
     # Make HTTP request with AWS Version 4 signing
 
@@ -91,6 +104,8 @@ def make_request(method,
     :param data_binary: bool
     :param verify: bool
     :param allow_redirects: false
+    :param tls_min: str
+    :param tls_max: str
 
     See also: http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
     """
@@ -154,9 +169,9 @@ def make_request(method,
         headers.update(auth_headers)
 
     if data_binary:
-        return __send_request(uri, data, headers, method, verify, allow_redirects)
+        return __send_request(uri, data, headers, method, verify, allow_redirects, tls_min, tls_max)
     else:
-        return __send_request(uri, data.encode('utf-8'), headers, method, verify, allow_redirects)
+        return __send_request(uri, data.encode('utf-8'), headers, method, verify, allow_redirects, tls_min, tls_max)
 
 
 def remove_default_port(parsed_url):
@@ -390,7 +405,7 @@ def __now():
     return datetime.datetime.utcnow()
 
 
-def __send_request(uri, data, headers, method, verify, allow_redirects):
+def __send_request(uri, data, headers, method, verify, allow_redirects, tls_min, tls_max):
     __log('\nHEADERS++++++++++++++++++++++++++++++++++++')
     __log(headers)
 
@@ -401,7 +416,27 @@ def __send_request(uri, data, headers, method, verify, allow_redirects):
         import urllib3
         urllib3.disable_warnings()
 
-    response = requests.request(method, uri, headers=headers, data=data, verify=verify, allow_redirects=allow_redirects)
+    class TLSAdapter(HTTPAdapter):
+        def init_poolmanager(self, *args, **kwargs):
+            ctx = create_urllib3_context()
+
+            tls_min_ver = TLS_VERSIONS.get(tls_min)
+            tls_max_ver = TLS_VERSIONS.get(tls_max)
+
+            if tls_min_ver is not None:
+                ctx.minimum_version = tls_min_ver
+            if tls_max_ver is not None:
+                ctx.maximum_version = tls_max_ver
+
+            if not verify:
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+            kwargs['ssl_context'] = ctx
+            super().init_poolmanager(*args, **kwargs)
+
+    session = requests.Session()
+    session.mount('https://', TLSAdapter())
+    response = session.request(method, uri, headers=headers, data=data, verify=verify, allow_redirects=allow_redirects)
 
     __log('\nRESPONSE++++++++++++++++++++++++++++++++++++')
     __log('Response code: %d\n' % response.status_code)
@@ -541,6 +576,8 @@ def inner_main(argv):
     parser.add_argument('-L', '--location', action='store_true', default=False,
                         help="Follow redirects")
     parser.add_argument('-o', '--output', metavar="<file>", help='Write to file instead of stdout', default='')
+    parser.add_argument('--tls_min', help='Set minimum allowed TLS version', choices=TLS_VERSIONS.keys())
+    parser.add_argument('--tls_max', help='Set maximum allowed TLS version', choices=TLS_VERSIONS.keys())
 
     parser.add_argument('uri')
 
@@ -590,7 +627,9 @@ def inner_main(argv):
                             args.session_token,
                             args.data_binary,
                             verify=not args.insecure,
-                            allow_redirects=args.location)
+                            allow_redirects=args.location,
+                            tls_min=args.tls_min,
+                            tls_max=args.tls_max)
 
     if args.include:
         print(response.headers, end='\n\n')

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -57,7 +57,7 @@ def my_mock_send_request_verify():
     class Object():
         pass
 
-    def ss(uri, data, headers, method, verify, allow_redirects, **kargs):
+    def ss(uri, data, headers, method, verify, allow_redirects, tls_min, tls_max, **kargs):
         print("in mock")
         if not verify:
             raise SSLError
@@ -217,6 +217,63 @@ class TestMakeRequestVerifySSLPass(TestCase):
         self.assertEqual(expected, headers)
 
         pass
+
+
+class TestMakeRequestWithTLSVersions(TestCase):
+    maxDiff = None
+
+    @patch('awscurl.awscurl.__now', new_callable=my_mock_utcnow)
+    def test_make_request(self, *args, **kvargs):
+        headers = {}
+        params = {'method': 'GET',
+                  'service': 'ec2',
+                  'region': 'region',
+                  'uri': 'https://user:pass@host:123/path/?a=b&c=d',
+                  'headers': headers,
+                  'data': '',
+                  'access_key': '',
+                  'secret_key': '',
+                  'security_token': '',
+                  'data_binary': False,
+                  'verify': True,
+                  'allow_redirects': False,
+                  'tls_min': '1.1',
+                  'tls_max': '1.3'}
+
+        with patch('awscurl.awscurl.__send_request') as mock_send:
+            make_request(**params)
+
+        mock_send.assert_called_once()
+        self.assertEqual('1.1', mock_send.call_args[0][6])
+        self.assertEqual('1.3', mock_send.call_args[0][7])
+
+
+class TestMakeRequestWithoutTLSVersions(TestCase):
+    maxDiff = None
+
+    @patch('awscurl.awscurl.__now', new_callable=my_mock_utcnow)
+    def test_make_request(self, *args, **kvargs):
+        headers = {}
+        params = {'method': 'GET',
+                  'service': 'ec2',
+                  'region': 'region',
+                  'uri': 'https://user:pass@host:123/path/?a=b&c=d',
+                  'headers': headers,
+                  'data': '',
+                  'access_key': '',
+                  'secret_key': '',
+                  'security_token': '',
+                  'data_binary': False,
+                  'verify': True,
+                  'allow_redirects': False}
+
+        with patch('awscurl.awscurl.__send_request') as mock_send:
+            make_request(**params)
+
+        mock_send.assert_called_once()
+        self.assertIsNone(mock_send.call_args[0][6])
+        self.assertIsNone(mock_send.call_args[0][7])
+
 
 class TestMakeRequestWithBinaryData(TestCase):
     maxDiff = None

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -244,8 +244,9 @@ class TestMakeRequestWithTLSVersions(TestCase):
             make_request(**params)
 
         mock_send.assert_called_once()
-        self.assertEqual('1.1', mock_send.call_args[0][6])
-        self.assertEqual('1.3', mock_send.call_args[0][7])
+        _, kwargs = mock_send.call_args
+        self.assertEqual('1.1', kwargs.get('tls_min', mock_send.call_args[0][6]))
+        self.assertEqual('1.3', kwargs.get('tls_max', mock_send.call_args[0][7]))
 
 
 class TestMakeRequestWithoutTLSVersions(TestCase):
@@ -271,8 +272,9 @@ class TestMakeRequestWithoutTLSVersions(TestCase):
             make_request(**params)
 
         mock_send.assert_called_once()
-        self.assertIsNone(mock_send.call_args[0][6])
-        self.assertIsNone(mock_send.call_args[0][7])
+        _, kwargs = mock_send.call_args
+        self.assertIsNone(kwargs.get('tls_min', mock_send.call_args[0][6]))
+        self.assertIsNone(kwargs.get('tls_max', mock_send.call_args[0][7]))
 
 
 class TestMakeRequestWithBinaryData(TestCase):


### PR DESCRIPTION
## What

Add `--tls-min` and `--tls-max` CLI options to control minimum and maximum
TLS versions for HTTPS requests. Supports TLS 1.0, 1.1, 1.2, and 1.3.

Based on #226 by @vyzigold, with the following fixes applied:
- Renamed `--tls_min`/`--tls_max` to `--tls-min`/`--tls-max` (curl naming convention)
- Moved TLS adapter to module level (avoid re-definition per request)
- Session is now properly closed after each request (fixes connection leak)
- Added validation that `--tls-min` does not exceed `--tls-max`

Closes #226

## Why

Some AWS endpoints or proxies require specific TLS version constraints.
curl supports `--tls-max` and `--tlsv1.x` — this brings similar control to awscurl.

## Testing

- [x] `pycodestyle awscurl` passes
- [x] `pytest -v --cov=awscurl --cov-fail-under=77` passes
- [x] No AWS credentials exposed in code or logs