### PR TITLE
Docs: checkup repo - bugs, vulnerability and errors

### DIFF
--- a/CHECKUP.md
+++ b/CHECKUP.md
@@ -1,0 +1,240 @@
+# Checkup do repositório `awscurl`
+
+Branch analisada: `claude/repo-checkup-review-EPd3L`
+HEAD: `89c74fa` (Bump version to 0.42 — add README as PyPI long_description)
+Data: 2026-05-18
+
+Sem commits / push / interação com GitHub feitos. Este documento é só leitura: lista vulnerabilidades, bugs, riscos e melhorias encontradas, com referência a arquivo:linha. Use-o como cardápio — depois você me diz o que atacar.
+
+## Sumário executivo
+
+| Severidade | Quantos | Categoria |
+| --- | --- | --- |
+| Alta | 4 | credenciais commitadas, log de credenciais em verbose, header SigV4 inconsistente (token vazio assinado/não assinado), `requirements.txt` sem pin |
+| Média | 8 | bugs de parsing (`split("=")`, `split(": ")`), `load_aws_config` com `while/break` quebrado, `utcnow()` deprecado, `-o` sempre duplica saída, publish via `setup.py sdist` deprecado, Docker login por senha, deps duplicadas no `setup.py`, falta `python_requires` |
+| Baixa | 7+ | imports duplicados, `pyrightconfig.json` órfão, `__log` usa `pprint`, `boto3` em `install_requires` sem uso direto, dockerfile alpine sem digest, MANIFEST.in ausente, validação `tls_min/max` só com ambos definidos |
+
+Status atual da suíte:
+- `pycodestyle awscurl` ✅
+- `mypy awscurl/ tests/` ✅ (`Success: no issues found in 12 source files`)
+- `pytest` offline (unit + stages + url_parsing + load_aws_config + basic) ✅ 23/23
+- `tests/integration_test.py` e `tests/tls_test.py::TestHTTPSDefaultTLS` exigem rede + creds reais (S3).
+
+---
+
+## 1. Vulnerabilidades de segurança
+
+### 1.1 [ALTA] Credenciais AWS reais commitadas em `tests/integration_test.py`
+Linhas 33-34, 56-57, 79-80, 102-103 — duas strings base64 que decodificam para um Access Key ID válido (formato `AKIA…`, 20 chars) + um Secret Access Key de 40 chars. As strings exatas estão no arquivo de teste; este documento intencionalmente não as reproduz para não disparar push-protection.
+
+Mesmo que sejam read-only para um bucket público, o padrão é tóxico:
+- Scanners (GitHub secret scanning, gitleaks, AWS GuardDuty) sinalizam — base64 dribla parte deles mas não todos.
+- Quem fizer fork passa a "possuir" essas chaves no histórico.
+- A AGENTS.md diz "Never log or expose AWS credentials" — esse padrão contraria a própria diretriz do projeto.
+
+**Sugestão:** usar `pytest.mark.skipif` quando credenciais reais não estiverem disponíveis e ler de env vars (`AWS_ACCESS_KEY_ID` etc.) ou de um perfil; rotacionar as chaves no IAM da AWS.
+
+### 1.2 [ALTA] `--verbose` vaza `access_key`/`secret_key`/tokens em stderr
+`awscurl/awscurl.py:608-609`:
+
+```python
+if args.verbose:
+    __log(vars(args))
+```
+
+`vars(args)` contém `access_key`, `secret_key`, `security_token`, `session_token`. AGENTS.md explicitamente proíbe ("Never log or expose AWS credentials — check `__log`, error paths, and `load_aws_config`"). Reproduz com `awscurl -v --access_key AKIA... ...` → stderr mostra a chave.
+
+**Sugestão:** redigir antes de logar (substituir os 4 campos por `***` numa cópia de `vars(args)`).
+
+### 1.3 [ALTA] Header `x-amz-security-token` enviado mas NÃO assinado quando token = `""`
+`awscurl/awscurl.py:243-244` (task_1) usa truthiness:
+
+```python
+if security_token:
+    canonical_headers_dict['x-amz-security-token'] = security_token
+```
+
+`awscurl/awscurl.py:371-372` (task_4) usa `is not None`:
+
+```python
+if security_token is not None:
+    headers['x-amz-security-token'] = security_token
+```
+
+Resultado com `security_token=""`: header sai no request mas não entra no canonical / `signed_headers`. AWS rejeita por SigV4 mismatch quando há um `x-amz-*` não assinado. O teste `tests/unit_test.py::TestMakeRequest::test_make_request` (linhas 90-95) congela esse bug como comportamento esperado (`'x-amz-security-token': ''` no expected).
+
+**Sugestão:** alinhar ambos para `if security_token:` (ou `is not None` com normalização para `None` em `normalize_args`), atualizar testes.
+
+### 1.4 [ALTA] `requirements.txt` sem pinning de versão
+`requirements.txt` lista `requests`, `configargparse`, `configparser`, `botocore` sem `==` nem `>=`. CI pega "latest" a cada execução — supply-chain weak point e CI flake. `setup.py` também tem `install_requires` sem pin.
+
+**Sugestão:** pinar versões mínimas testadas (`requests>=2.32,<3`, etc.) e considerar `pip-compile` para gerar `requirements.lock`.
+
+### 1.5 [MÉDIA] Docker Hub login com senha (`DOCKER_PASSWORD`)
+`.github/workflows/dockerhubpublish.yml:14`. Docker Hub recomenda **access tokens** (`DOCKER_TOKEN`) com escopo restrito; senha dá acesso total à conta.
+
+### 1.6 [MÉDIA] PyPI publish com user/senha (`TWINE_USERNAME`/`TWINE_PASSWORD`)
+`.github/workflows/pythonpublish.yml:21-22`. PyPI hoje obriga 2FA — recomenda **trusted publishing (OIDC)** ou pelo menos `TWINE_USERNAME=__token__` + token de projeto.
+
+### 1.7 [MÉDIA] `_TLSAdapter` desativa verificação de hostname e CN quando `--insecure`
+`awscurl/awscurl.py:430-432` — comportamento intencional (curl `-k` faz o mesmo). Mas é importante garantir que `--insecure` continue exclusivo a essa flag e nunca seja default; OK pelo código atual, vale uma nota.
+
+### 1.8 [BAIXA] Dockerfile não pina digest da imagem base
+`Dockerfile:2`/`19`: `python:3-alpine`. Build reprodutível e seguro exigem `python:3.13.3-alpine@sha256:...`. Idem para os Dockerfiles em `ci/ci-*/Dockerfile`.
+
+### 1.9 [BAIXA] CI Dockerfiles instalam pyenv via `curl | bash`
+`ci/ci-*/Dockerfile`: `RUN curl https://pyenv.run | bash`. Roda código remoto não verificado em build de CI; risco de supply chain. Fora do hot path (só CI manual), mas vale conhecer.
+
+---
+
+## 2. Bugs funcionais
+
+### 2.1 [MÉDIA] `__normalize_query_string` quebra valores com `=` no meio
+`awscurl/awscurl.py:384-391`:
+
+```python
+parameter_pairs = (list(map(str.strip, s.split("=")))
+                   for s in query.split('&') if len(s) > 0)
+normalized = '&'.join('%s=%s' % (aws_url_encode(p[0]), aws_url_encode(p[1]) if len(p) > 1 else '')
+                      for p in sorted(parameter_pairs))
+```
+
+Para `?token=abc=def`, `split("=")` → `['token','abc','def']`; só `p[0]`/`p[1]` são usados → vira `token=abc`, perdendo `=def`. Deveria ser `s.split("=", 1)`. Também o `str.strip` em valores muda assinatura para queries que legitimamente contenham espaço (improvável, mas a especificação SigV4 não pede strip de valor).
+
+### 2.2 [MÉDIA] `load_aws_config` para no primeiro campo faltante
+`awscurl/awscurl.py:480-494`:
+
+```python
+while True:
+    if access_key is None and config.has_option(profile, "aws_access_key_id"):
+        access_key = config.get(profile, "aws_access_key_id")
+    else:
+        break
+    if secret_key is None and config.has_option(profile, "aws_secret_access_key"):
+        ...
+```
+
+Se quem chama já passa `access_key` mas não `secret_key`, a primeira condição cai no `else: break` e `secret_key` nunca é lido do arquivo. O `while True` aqui é "if-em-disfarce" e a lógica de short-circuit está invertida. Reescrever sem o loop, lendo cada campo independentemente.
+
+### 2.3 [MÉDIA] Parse de header com mais de um `": "` levanta exceção
+`awscurl/awscurl.py:623`:
+
+```python
+headers = {k: v for (k, v) in map(lambda s: s.split(": "), args.header)}
+```
+
+`-H "Authorization: Bearer foo: bar"` → `split(": ")` produz 3 itens → `ValueError: too many values to unpack`. Usar `s.split(": ", 1)`.
+
+### 2.4 [MÉDIA] `-o`/`--output` sempre duplica saída em stdout
+`awscurl/awscurl.py:660-669`: `print(response.text)` roda sempre; só depois é que `args.output` grava arquivo. No curl, `-o file` redireciona — não duplica. Hoje saída vai para stdout E para o arquivo.
+
+### 2.5 [MÉDIA] `--data-binary` controla o modo de escrita do `--output`
+`awscurl/awscurl.py:663-669`: o modo de gravação (`"wb"` vs `"w"`) depende de `args.data_binary`, mas `data_binary` é flag do **request**, não da **resposta**. Quem envia JSON e recebe binário fica com arquivo corrompido. Decisão deveria vir de algo como `--output-binary` ou sempre `"wb"` com `response.content`.
+
+### 2.6 [MÉDIA] `make_request` sempre chama `datetime.utcnow()` (deprecado)
+`awscurl/awscurl.py:407-408`:
+
+```python
+def __now():
+    return datetime.datetime.utcnow()
+```
+
+`utcnow()` está marcado como deprecated no Python 3.12+ (devolve naive datetime). Trocar por `datetime.datetime.now(datetime.timezone.utc)`. Não quebra hoje, mas vai gerar `DeprecationWarning` e algum dia será removido. CI já roda 3.13 (`.python-version`).
+
+### 2.7 [MÉDIA] `--tls-min`/`--tls-max` só valida ordem se ambos forem passados
+`awscurl/awscurl.py:448-452`: `if tls_min is not None and tls_max is not None`. Pedido só `--tls-min 1.3` com sistema cuja `maximum_version` é 1.2 vai falhar no handshake sem mensagem clara. Validação simples: comparar contra os limites suportados pelo Python/openssl.
+
+### 2.8 [MÉDIA] `--access_key`/`--secret_key`/`--security_token`/`--session_token` quebram convenção curl
+README e AGENTS dizem "siga a convenção do curl". O resto das flags usa hífen (`--data-binary`, `--fail-with-body`, `--tls-min`), mas essas quatro usam underscore. Manter aliases (`--access-key` + `--access_key`) com `dest=` resolveria sem quebrar backward compat.
+
+### 2.9 [BAIXA] `import urllib` + `from urllib.parse import quote` redundantes
+`awscurl/awscurl.py:21-22`. Já existe `urllib.parse.urlparse` na linha 230; pode-se reduzir para `from urllib.parse import urlparse, quote`.
+
+### 2.10 [BAIXA] `from typing import Dict` duplicado
+`awscurl/awscurl.py:7` e `:20`. mypy aceita, pycodestyle não pega, mas é ruído.
+
+### 2.11 [BAIXA] `url_path_to_dict` faz regex próprio em vez de `urllib.parse.urlparse`
+`awscurl/awscurl.py:54-75`. O regex é frágil (e o comentário admite: copiado do StackOverflow). `urlparse` cobre os casos testados; mantê-lo encoberto pelos testes está OK mas vale a refatoração.
+
+### 2.12 [BAIXA] `botocore` import "opcional" é dead code
+`awscurl/awscurl.py:509-519`: `try: import botocore` num `try/except ImportError`, mas `botocore` já é import top-level obrigatório na linha 18. Sempre cai no caminho feliz; o `except ImportError` é inalcançável.
+
+### 2.13 [BAIXA] `credentials_path` monta path com `+ "/.aws/credentials"`
+`awscurl/awscurl.py:626`. Quebra em Windows; usar `os.path.join(os.path.expanduser("~"), ".aws", "credentials")` ou `pathlib.Path.home() / ".aws" / "credentials"`.
+
+---
+
+## 3. Dependências / packaging
+
+### 3.1 [MÉDIA] `setup.py:36` lista `configparser` (backport de Py2) — supérfluo em Py3
+`configparser` é stdlib desde Py3.0. Manter força usuários a baixar um pacote inútil.
+
+### 3.2 [MÉDIA] `setup.py:39` lista `boto3` em `install_requires` sem uso
+O código importa só `botocore` (`from botocore import crt, awsrequest` etc.). `boto3` arrasta s3transfer + dependências grandes (~10MB extra). Remover.
+
+### 3.3 [MÉDIA] `setup.py` sem `python_requires`
+CI testa Py 3.10/3.11/3.12/3.13, mas o pacote permite `pip install` em qualquer versão. Tipagem `dict[str, str]` em `tests/unit_test.py:77` quebra em <3.9. Adicionar `python_requires=">=3.10"`.
+
+### 3.4 [BAIXA] `MANIFEST.in` inexistente apesar de `setup.py` ler `README.md` para long_description
+`setup.py:9-10` faz `open("README.md")` em build time. setuptools moderno inclui README.md por padrão no sdist, mas é frágil; adicionar `MANIFEST.in` com `include README.md LICENSE` previne quebra de instalação por sdist.
+
+### 3.5 [BAIXA] Publish workflow ainda usa `python setup.py sdist bdist_wheel`
+`scripts/pypi_publish.sh:5` e `.github/workflows/pythonpublish.yml:23`. setuptools deprecou o uso direto; usar `python -m build`.
+
+### 3.6 [BAIXA] `pyrightconfig.json` órfão
+Arquivo existe mas nenhum step de CI roda pyright (só `mypy`). Ou usar (substituir `mypy` por `pyright` em `pythonapp.yml`) ou remover.
+
+---
+
+## 4. CI/CD
+
+### 4.1 Matriz redundante
+`pythonapp.yml`: roda `ubuntu-22.04`, `ubuntu-24.04`, `ubuntu-latest` em paralelo. `ubuntu-latest` hoje é `24.04` (vai virar `26.04` em algum momento). Tem teste duplicado. Manter `ubuntu-22.04` + `ubuntu-latest` cobre o útil.
+
+### 4.2 Sem cache de pip
+Nenhum step usa `actions/setup-python` com `cache: pip`. Cada job baixa dependências do zero (~4 jobs * 4 Python versions = 16 instalações). Adicionar `cache: pip` corta minutos de CI.
+
+### 4.3 `--cov-fail-under=77` é baixo demais
+Coverage gate é 77%. Vale checar onde está o gap (provavelmente `load_aws_config` e ramos de erro). Subir progressivamente.
+
+### 4.4 Workflows sem `permissions:` mínimo
+Nenhum YAML define `permissions:` — runs herdam o default do repo. Boa prática é `permissions: contents: read` no topo e elevar por job (e.g. `packages: write` só onde publica imagem).
+
+### 4.5 Sem job de lint dedicado para o Dockerfile
+`hadolint` seria útil; o `Dockerfile` atual tem `pip install --user botocore` no estágio builder (linha 11) que é redundante com o `pip install /app-source-dir` da linha 15.
+
+---
+
+## 5. Documentação / governança
+
+- `README.md` lista opções em uma seção "Options" copiada à mão; já desatualizou (não menciona `--tls-min`/`--tls-max`). Gerar via `argparse-manpage` ou similar evita drift.
+- `DEVELOP.md` tem 11 linhas; instruções de venv local estão escondidas no `Makefile`. Unir.
+- `.github/PULL_REQUEST_TEMPLATE.md` não foi auditado aqui, mas vale conferir se pede checklist de testes.
+- Não há `SECURITY.md` orientando como reportar CVE — adicionar.
+- Não há `CHANGELOG.md`; releases ficam só no GitHub.
+
+---
+
+## 6. Lista priorizada (para discutir o que atacar primeiro)
+
+1. **Tirar chaves AWS dos testes** (§1.1) — fix isolado em `tests/integration_test.py`, requer rotação na AWS.
+2. **Não logar credenciais em `--verbose`** (§1.2) — patch de ~5 linhas em `inner_main`.
+3. **Consertar `x-amz-security-token` inconsistente** (§1.3) — afeta SigV4 com token vazio; testes precisam ajustar.
+4. **Pinar deps mínimas em `requirements.txt` + `setup.py`** (§1.4, §3.1, §3.2, §3.3).
+5. **Fix de parsing** (§2.1, §2.3) — bugs sutis com payloads reais.
+6. **`load_aws_config` while/break invertido** (§2.2).
+7. **Comportamento de `-o`** (§2.4, §2.5).
+8. **`utcnow()` deprecation** (§2.6).
+9. **CI permissions/cache/matrix** (§4.x).
+10. **Limpeza/refactor** (§2.9-2.13, §3.5, §3.6).
+
+---
+
+## 7. Como verifiquei
+
+- Leitura integral de: `awscurl/{awscurl.py,utils.py,__main__.py,__init__.py}`, `setup.py`, `setup.cfg`, `requirements*.txt`, `Dockerfile`, `Makefile`, `scripts/*`, `tests/*`, `.github/workflows/*`, `.github/{dependabot.yml,CODEOWNERS,copilot-instructions.md}`, `ci/*/Dockerfile`.
+- `pycodestyle -v awscurl` → 0 issues.
+- `mypy awscurl/ tests/` → 0 issues.
+- `pytest` offline (excluindo `integration_test.py` e `tls_test.py::TestHTTPSDefaultTLS`) → 23 passed.
+- Decodificação fora-da-árvore das strings base64 em `integration_test.py` para confirmar que os bytes formam um access key + secret válidos no formato AWS (não reproduzidos aqui).
+- Histórico de commits via `git log --oneline -20` para entender baseline e PRs recentes (#235, #232-#234).

--- a/CHECKUP.md
+++ b/CHECKUP.md
@@ -1,40 +1,44 @@
-# Checkup do repositório `awscurl`
+# `awscurl` repository checkup
 
-Branch analisada: `claude/repo-checkup-review-EPd3L`
-HEAD: `89c74fa` (Bump version to 0.42 — add README as PyPI long_description)
-Data: 2026-05-18
+Branch reviewed: `claude/repo-checkup-review-EPd3L`
+HEAD at audit time: `89c74fa` ("Bump version to 0.42 — add README as PyPI long_description")
+Audit date: 2026-05-18
 
-Sem commits / push / interação com GitHub feitos. Este documento é só leitura: lista vulnerabilidades, bugs, riscos e melhorias encontradas, com referência a arquivo:linha. Use-o como cardápio — depois você me diz o que atacar.
+This document is read-only: an inventory of vulnerabilities, bugs, risks, and improvements, with file:line references. No source changes are made here. Use it as a menu and pick what to fix next.
 
-## Sumário executivo
+## Executive summary
 
-| Severidade | Quantos | Categoria |
+| Severity | Count | Theme |
 | --- | --- | --- |
-| Alta | 4 | credenciais commitadas, log de credenciais em verbose, header SigV4 inconsistente (token vazio assinado/não assinado), `requirements.txt` sem pin |
-| Média | 8 | bugs de parsing (`split("=")`, `split(": ")`), `load_aws_config` com `while/break` quebrado, `utcnow()` deprecado, `-o` sempre duplica saída, publish via `setup.py sdist` deprecado, Docker login por senha, deps duplicadas no `setup.py`, falta `python_requires` |
-| Baixa | 7+ | imports duplicados, `pyrightconfig.json` órfão, `__log` usa `pprint`, `boto3` em `install_requires` sem uso direto, dockerfile alpine sem digest, MANIFEST.in ausente, validação `tls_min/max` só com ambos definidos |
+| High | 4 | Committed AWS credentials in tests; credentials logged in `--verbose`; SigV4 header inconsistency for empty security token; unpinned `requirements.txt` |
+| Medium | 8 | Parsing bugs (`split("=")`, `split(": ")`); broken `while/break` in `load_aws_config`; deprecated `utcnow()`; `-o` duplicates output; deprecated `setup.py sdist` publish; Docker login via password; duplicate / extra deps in `setup.py`; missing `python_requires` |
+| Low | 7+ | Duplicate imports; orphan `pyrightconfig.json`; `__log` uses `pprint`; `boto3` in `install_requires` with no direct use; Dockerfile base images not pinned by digest; missing `MANIFEST.in`; `tls_min/max` validation only triggers when both flags are set |
 
-Status atual da suíte:
-- `pycodestyle awscurl` ✅
-- `mypy awscurl/ tests/` ✅ (`Success: no issues found in 12 source files`)
-- `pytest` offline (unit + stages + url_parsing + load_aws_config + basic) ✅ 23/23
-- `tests/integration_test.py` e `tests/tls_test.py::TestHTTPSDefaultTLS` exigem rede + creds reais (S3).
+Current suite status:
+
+- `pycodestyle awscurl` -> 0 issues.
+- `mypy awscurl/ tests/` -> 0 issues (`Success: no issues found in 12 source files`).
+- Offline `pytest` (unit + stages + url_parsing + load_aws_config + basic) -> 23/23 passing.
+- `tests/integration_test.py` and `tests/tls_test.py::TestHTTPSDefaultTLS` require network and live S3 — not exercised here.
 
 ---
 
-## 1. Vulnerabilidades de segurança
+## 1. Security findings
 
-### 1.1 [ALTA] Credenciais AWS reais commitadas em `tests/integration_test.py`
-Linhas 33-34, 56-57, 79-80, 102-103 — duas strings base64 que decodificam para um Access Key ID válido (formato `AKIA…`, 20 chars) + um Secret Access Key de 40 chars. As strings exatas estão no arquivo de teste; este documento intencionalmente não as reproduz para não disparar push-protection.
+### 1.1 [HIGH] Real AWS credentials committed in `tests/integration_test.py`
 
-Mesmo que sejam read-only para um bucket público, o padrão é tóxico:
-- Scanners (GitHub secret scanning, gitleaks, AWS GuardDuty) sinalizam — base64 dribla parte deles mas não todos.
-- Quem fizer fork passa a "possuir" essas chaves no histórico.
-- A AGENTS.md diz "Never log or expose AWS credentials" — esse padrão contraria a própria diretriz do projeto.
+Lines 33-34, 56-57, 79-80, 102-103 contain two base64-encoded strings that decode to a valid AWS Access Key ID (`AKIA…` format, 20 chars) and a 40-character Secret Access Key. The exact strings are in the test file; this document intentionally does not reproduce them to avoid tripping push protection.
 
-**Sugestão:** usar `pytest.mark.skipif` quando credenciais reais não estiverem disponíveis e ler de env vars (`AWS_ACCESS_KEY_ID` etc.) ou de um perfil; rotacionar as chaves no IAM da AWS.
+Even if these keys are read-only for a public bucket, the pattern is toxic:
 
-### 1.2 [ALTA] `--verbose` vaza `access_key`/`secret_key`/tokens em stderr
+- Scanners (GitHub secret scanning, gitleaks, AWS GuardDuty) flag them; base64 evades some but not all.
+- Anyone who forks the repo inherits the keys in their history.
+- `AGENTS.md` says "Never log or expose AWS credentials" — committing them in source contradicts the project's own directive.
+
+Suggested fix: use `pytest.mark.skipif` when real credentials are not available, and read them from env vars (`AWS_ACCESS_KEY_ID`, etc.) or from a profile; rotate the keys in AWS IAM.
+
+### 1.2 [HIGH] `--verbose` leaks `access_key` / `secret_key` / tokens to stderr
+
 `awscurl/awscurl.py:608-609`:
 
 ```python
@@ -42,54 +46,62 @@ if args.verbose:
     __log(vars(args))
 ```
 
-`vars(args)` contém `access_key`, `secret_key`, `security_token`, `session_token`. AGENTS.md explicitamente proíbe ("Never log or expose AWS credentials — check `__log`, error paths, and `load_aws_config`"). Reproduz com `awscurl -v --access_key AKIA... ...` → stderr mostra a chave.
+`vars(args)` contains `access_key`, `secret_key`, `security_token`, and `session_token`. `AGENTS.md` explicitly forbids this ("Never log or expose AWS credentials — check `__log`, error paths, and `load_aws_config`"). Reproducible with `awscurl -v --access_key AKIA... ...` — the key shows up in stderr.
 
-**Sugestão:** redigir antes de logar (substituir os 4 campos por `***` numa cópia de `vars(args)`).
+Suggested fix: redact before logging (replace the four credential fields with `***` in a copy of `vars(args)`).
 
-### 1.3 [ALTA] Header `x-amz-security-token` enviado mas NÃO assinado quando token = `""`
-`awscurl/awscurl.py:243-244` (task_1) usa truthiness:
+### 1.3 [HIGH] `x-amz-security-token` header is sent but NOT signed when token is `""`
+
+`awscurl/awscurl.py:243-244` (`task_1`) uses truthiness:
 
 ```python
 if security_token:
     canonical_headers_dict['x-amz-security-token'] = security_token
 ```
 
-`awscurl/awscurl.py:371-372` (task_4) usa `is not None`:
+`awscurl/awscurl.py:371-372` (`task_4`) uses `is not None`:
 
 ```python
 if security_token is not None:
     headers['x-amz-security-token'] = security_token
 ```
 
-Resultado com `security_token=""`: header sai no request mas não entra no canonical / `signed_headers`. AWS rejeita por SigV4 mismatch quando há um `x-amz-*` não assinado. O teste `tests/unit_test.py::TestMakeRequest::test_make_request` (linhas 90-95) congela esse bug como comportamento esperado (`'x-amz-security-token': ''` no expected).
+With `security_token=""`, the header is sent in the request but is not added to the canonical headers / `signed_headers`. AWS rejects SigV4 requests where an `x-amz-*` header is sent unsigned, so this produces signature mismatches. `tests/unit_test.py::TestMakeRequest::test_make_request` (lines 90-95) freezes the bug as expected behavior (`'x-amz-security-token': ''` appears in the expected dict).
 
-**Sugestão:** alinhar ambos para `if security_token:` (ou `is not None` com normalização para `None` em `normalize_args`), atualizar testes.
+Suggested fix: align both functions on `if security_token:` (or `is not None` with normalization to `None` in `normalize_args`), and update the tests.
 
-### 1.4 [ALTA] `requirements.txt` sem pinning de versão
-`requirements.txt` lista `requests`, `configargparse`, `configparser`, `botocore` sem `==` nem `>=`. CI pega "latest" a cada execução — supply-chain weak point e CI flake. `setup.py` também tem `install_requires` sem pin.
+### 1.4 [HIGH] `requirements.txt` is not pinned
 
-**Sugestão:** pinar versões mínimas testadas (`requests>=2.32,<3`, etc.) e considerar `pip-compile` para gerar `requirements.lock`.
+`requirements.txt` lists `requests`, `configargparse`, `configparser`, `botocore` with no `==` or `>=`. CI pulls "latest" on every run — supply-chain weakness and CI flakiness. `setup.py` has the same problem in `install_requires`.
 
-### 1.5 [MÉDIA] Docker Hub login com senha (`DOCKER_PASSWORD`)
-`.github/workflows/dockerhubpublish.yml:14`. Docker Hub recomenda **access tokens** (`DOCKER_TOKEN`) com escopo restrito; senha dá acesso total à conta.
+Suggested fix: pin minimum tested versions (`requests>=2.32,<3`, etc.) and consider `pip-compile` to generate a `requirements.lock`.
 
-### 1.6 [MÉDIA] PyPI publish com user/senha (`TWINE_USERNAME`/`TWINE_PASSWORD`)
-`.github/workflows/pythonpublish.yml:21-22`. PyPI hoje obriga 2FA — recomenda **trusted publishing (OIDC)** ou pelo menos `TWINE_USERNAME=__token__` + token de projeto.
+### 1.5 [MEDIUM] Docker Hub login uses password (`DOCKER_PASSWORD`)
 
-### 1.7 [MÉDIA] `_TLSAdapter` desativa verificação de hostname e CN quando `--insecure`
-`awscurl/awscurl.py:430-432` — comportamento intencional (curl `-k` faz o mesmo). Mas é importante garantir que `--insecure` continue exclusivo a essa flag e nunca seja default; OK pelo código atual, vale uma nota.
+`.github/workflows/dockerhubpublish.yml:14`. Docker Hub recommends **access tokens** (`DOCKER_TOKEN`) with restricted scope; a password grants full account access.
 
-### 1.8 [BAIXA] Dockerfile não pina digest da imagem base
-`Dockerfile:2`/`19`: `python:3-alpine`. Build reprodutível e seguro exigem `python:3.13.3-alpine@sha256:...`. Idem para os Dockerfiles em `ci/ci-*/Dockerfile`.
+### 1.6 [MEDIUM] PyPI publish uses user / password (`TWINE_USERNAME` / `TWINE_PASSWORD`)
 
-### 1.9 [BAIXA] CI Dockerfiles instalam pyenv via `curl | bash`
-`ci/ci-*/Dockerfile`: `RUN curl https://pyenv.run | bash`. Roda código remoto não verificado em build de CI; risco de supply chain. Fora do hot path (só CI manual), mas vale conhecer.
+`.github/workflows/pythonpublish.yml:21-22`. PyPI now requires 2FA — switch to **trusted publishing (OIDC)** or at minimum `TWINE_USERNAME=__token__` plus a project-scoped API token.
+
+### 1.7 [MEDIUM] `_TLSAdapter` disables hostname and CN verification when `--insecure`
+
+`awscurl/awscurl.py:430-432` — intentional behavior (matches curl `-k`). It is important that `--insecure` remains opt-in and never becomes a default; the current code does that correctly. Worth a note, not a fix.
+
+### 1.8 [LOW] Dockerfile does not pin the base image digest
+
+`Dockerfile:2` / `:19`: `python:3-alpine`. Reproducible and tamper-resistant builds require a digest pin like `python:3.13.3-alpine@sha256:...`. Same applies to `ci/ci-*/Dockerfile`.
+
+### 1.9 [LOW] CI Dockerfiles install pyenv via `curl | bash`
+
+`ci/ci-*/Dockerfile`: `RUN curl https://pyenv.run | bash`. Runs unauthenticated remote code during CI build — supply-chain risk. Not in the hot path (manual CI only), but worth noting.
 
 ---
 
-## 2. Bugs funcionais
+## 2. Functional bugs
 
-### 2.1 [MÉDIA] `__normalize_query_string` quebra valores com `=` no meio
+### 2.1 [MEDIUM] `__normalize_query_string` drops parts of values containing `=`
+
 `awscurl/awscurl.py:384-391`:
 
 ```python
@@ -99,9 +111,10 @@ normalized = '&'.join('%s=%s' % (aws_url_encode(p[0]), aws_url_encode(p[1]) if l
                       for p in sorted(parameter_pairs))
 ```
 
-Para `?token=abc=def`, `split("=")` → `['token','abc','def']`; só `p[0]`/`p[1]` são usados → vira `token=abc`, perdendo `=def`. Deveria ser `s.split("=", 1)`. Também o `str.strip` em valores muda assinatura para queries que legitimamente contenham espaço (improvável, mas a especificação SigV4 não pede strip de valor).
+For `?token=abc=def`, `split("=")` returns `['token','abc','def']`; only `p[0]` and `p[1]` are used, so the result becomes `token=abc`, losing `=def`. Fix: `s.split("=", 1)`. The `str.strip` on values is also suspect — SigV4 does not require stripping query values, and stripping breaks values that legitimately start or end with whitespace (rare, but worth removing).
 
-### 2.2 [MÉDIA] `load_aws_config` para no primeiro campo faltante
+### 2.2 [MEDIUM] `load_aws_config` stops at the first missing field
+
 `awscurl/awscurl.py:480-494`:
 
 ```python
@@ -114,24 +127,28 @@ while True:
         ...
 ```
 
-Se quem chama já passa `access_key` mas não `secret_key`, a primeira condição cai no `else: break` e `secret_key` nunca é lido do arquivo. O `while True` aqui é "if-em-disfarce" e a lógica de short-circuit está invertida. Reescrever sem o loop, lendo cada campo independentemente.
+If the caller passes `access_key` but not `secret_key`, the first condition falls into the `else: break` and `secret_key` is never read from the file. The `while True` is an "if in disguise" and the short-circuit logic is inverted. Rewrite without the loop, reading each field independently.
 
-### 2.3 [MÉDIA] Parse de header com mais de um `": "` levanta exceção
+### 2.3 [MEDIUM] Parsing a header with more than one `": "` raises `ValueError`
+
 `awscurl/awscurl.py:623`:
 
 ```python
 headers = {k: v for (k, v) in map(lambda s: s.split(": "), args.header)}
 ```
 
-`-H "Authorization: Bearer foo: bar"` → `split(": ")` produz 3 itens → `ValueError: too many values to unpack`. Usar `s.split(": ", 1)`.
+`-H "Authorization: Bearer foo: bar"` — `split(": ")` returns 3 items, so the dict comprehension fails with `ValueError: too many values to unpack`. Use `s.split(": ", 1)`.
 
-### 2.4 [MÉDIA] `-o`/`--output` sempre duplica saída em stdout
-`awscurl/awscurl.py:660-669`: `print(response.text)` roda sempre; só depois é que `args.output` grava arquivo. No curl, `-o file` redireciona — não duplica. Hoje saída vai para stdout E para o arquivo.
+### 2.4 [MEDIUM] `-o` / `--output` always duplicates output to stdout
 
-### 2.5 [MÉDIA] `--data-binary` controla o modo de escrita do `--output`
-`awscurl/awscurl.py:663-669`: o modo de gravação (`"wb"` vs `"w"`) depende de `args.data_binary`, mas `data_binary` é flag do **request**, não da **resposta**. Quem envia JSON e recebe binário fica com arquivo corrompido. Decisão deveria vir de algo como `--output-binary` ou sempre `"wb"` com `response.content`.
+`awscurl/awscurl.py:660-669`: `print(response.text)` runs unconditionally; `args.output` only writes the file afterwards. curl's `-o file` redirects — it does not duplicate. Today the body lands both on stdout and in the file.
 
-### 2.6 [MÉDIA] `make_request` sempre chama `datetime.utcnow()` (deprecado)
+### 2.5 [MEDIUM] `--data-binary` controls the write mode of `--output`
+
+`awscurl/awscurl.py:663-669`: the file write mode (`"wb"` vs `"w"`) depends on `args.data_binary`, but `data_binary` is a **request** flag, not a **response** flag. A user who sends JSON and receives binary ends up with a corrupted file. The decision should come from something like `--output-binary`, or always use `"wb"` with `response.content`.
+
+### 2.6 [MEDIUM] `make_request` always calls `datetime.utcnow()` (deprecated)
+
 `awscurl/awscurl.py:407-408`:
 
 ```python
@@ -139,102 +156,120 @@ def __now():
     return datetime.datetime.utcnow()
 ```
 
-`utcnow()` está marcado como deprecated no Python 3.12+ (devolve naive datetime). Trocar por `datetime.datetime.now(datetime.timezone.utc)`. Não quebra hoje, mas vai gerar `DeprecationWarning` e algum dia será removido. CI já roda 3.13 (`.python-version`).
+`utcnow()` is deprecated on Python 3.12+ (returns naive datetime). Replace with `datetime.datetime.now(datetime.timezone.utc)`. It still works today but emits `DeprecationWarning` and will eventually be removed. CI already runs 3.13 (`.python-version`).
 
-### 2.7 [MÉDIA] `--tls-min`/`--tls-max` só valida ordem se ambos forem passados
-`awscurl/awscurl.py:448-452`: `if tls_min is not None and tls_max is not None`. Pedido só `--tls-min 1.3` com sistema cuja `maximum_version` é 1.2 vai falhar no handshake sem mensagem clara. Validação simples: comparar contra os limites suportados pelo Python/openssl.
+### 2.7 [MEDIUM] `--tls-min` / `--tls-max` only validate order when both are supplied
 
-### 2.8 [MÉDIA] `--access_key`/`--secret_key`/`--security_token`/`--session_token` quebram convenção curl
-README e AGENTS dizem "siga a convenção do curl". O resto das flags usa hífen (`--data-binary`, `--fail-with-body`, `--tls-min`), mas essas quatro usam underscore. Manter aliases (`--access-key` + `--access_key`) com `dest=` resolveria sem quebrar backward compat.
+`awscurl/awscurl.py:448-452`: `if tls_min is not None and tls_max is not None`. A user who passes only `--tls-min 1.3` on a system whose `maximum_version` is 1.2 gets an opaque handshake failure. A simple check against the supported limits would help.
 
-### 2.9 [BAIXA] `import urllib` + `from urllib.parse import quote` redundantes
-`awscurl/awscurl.py:21-22`. Já existe `urllib.parse.urlparse` na linha 230; pode-se reduzir para `from urllib.parse import urlparse, quote`.
+### 2.8 [MEDIUM] `--access_key` / `--secret_key` / `--security_token` / `--session_token` break curl's naming convention
 
-### 2.10 [BAIXA] `from typing import Dict` duplicado
-`awscurl/awscurl.py:7` e `:20`. mypy aceita, pycodestyle não pega, mas é ruído.
+The README and `AGENTS.md` say to "follow curl's style and naming conventions". The rest of the flags use hyphens (`--data-binary`, `--fail-with-body`, `--tls-min`), but these four use underscores. Adding aliases (`--access-key` next to `--access_key`) via `dest=` would fix this without breaking backwards compatibility.
 
-### 2.11 [BAIXA] `url_path_to_dict` faz regex próprio em vez de `urllib.parse.urlparse`
-`awscurl/awscurl.py:54-75`. O regex é frágil (e o comentário admite: copiado do StackOverflow). `urlparse` cobre os casos testados; mantê-lo encoberto pelos testes está OK mas vale a refatoração.
+### 2.9 [LOW] Redundant `import urllib` + `from urllib.parse import quote`
 
-### 2.12 [BAIXA] `botocore` import "opcional" é dead code
-`awscurl/awscurl.py:509-519`: `try: import botocore` num `try/except ImportError`, mas `botocore` já é import top-level obrigatório na linha 18. Sempre cai no caminho feliz; o `except ImportError` é inalcançável.
+`awscurl/awscurl.py:21-22`. `urllib.parse.urlparse` is already used on line 230; collapse into `from urllib.parse import urlparse, quote`.
 
-### 2.13 [BAIXA] `credentials_path` monta path com `+ "/.aws/credentials"`
-`awscurl/awscurl.py:626`. Quebra em Windows; usar `os.path.join(os.path.expanduser("~"), ".aws", "credentials")` ou `pathlib.Path.home() / ".aws" / "credentials"`.
+### 2.10 [LOW] Duplicate `from typing import Dict`
 
----
+`awscurl/awscurl.py:7` and `:20`. mypy accepts it, pycodestyle does not flag it, but it is noise.
 
-## 3. Dependências / packaging
+### 2.11 [LOW] `url_path_to_dict` rolls its own regex instead of `urllib.parse.urlparse`
 
-### 3.1 [MÉDIA] `setup.py:36` lista `configparser` (backport de Py2) — supérfluo em Py3
-`configparser` é stdlib desde Py3.0. Manter força usuários a baixar um pacote inútil.
+`awscurl/awscurl.py:54-75`. The regex is fragile (the comment admits it was copied from StackOverflow). `urlparse` covers every case the tests assert; the existing tests would still pass after the refactor.
 
-### 3.2 [MÉDIA] `setup.py:39` lista `boto3` em `install_requires` sem uso
-O código importa só `botocore` (`from botocore import crt, awsrequest` etc.). `boto3` arrasta s3transfer + dependências grandes (~10MB extra). Remover.
+### 2.12 [LOW] The "optional" `botocore` import is dead code
 
-### 3.3 [MÉDIA] `setup.py` sem `python_requires`
-CI testa Py 3.10/3.11/3.12/3.13, mas o pacote permite `pip install` em qualquer versão. Tipagem `dict[str, str]` em `tests/unit_test.py:77` quebra em <3.9. Adicionar `python_requires=">=3.10"`.
+`awscurl/awscurl.py:509-519`: `try: import botocore` inside a `try/except ImportError`, but `botocore` is already a top-level import on line 18. The happy path is always taken; the `except ImportError` is unreachable.
 
-### 3.4 [BAIXA] `MANIFEST.in` inexistente apesar de `setup.py` ler `README.md` para long_description
-`setup.py:9-10` faz `open("README.md")` em build time. setuptools moderno inclui README.md por padrão no sdist, mas é frágil; adicionar `MANIFEST.in` com `include README.md LICENSE` previne quebra de instalação por sdist.
+### 2.13 [LOW] `credentials_path` is built with `+ "/.aws/credentials"`
 
-### 3.5 [BAIXA] Publish workflow ainda usa `python setup.py sdist bdist_wheel`
-`scripts/pypi_publish.sh:5` e `.github/workflows/pythonpublish.yml:23`. setuptools deprecou o uso direto; usar `python -m build`.
-
-### 3.6 [BAIXA] `pyrightconfig.json` órfão
-Arquivo existe mas nenhum step de CI roda pyright (só `mypy`). Ou usar (substituir `mypy` por `pyright` em `pythonapp.yml`) ou remover.
+`awscurl/awscurl.py:626`. Breaks on Windows; use `os.path.join(os.path.expanduser("~"), ".aws", "credentials")` or `pathlib.Path.home() / ".aws" / "credentials"`.
 
 ---
 
-## 4. CI/CD
+## 3. Dependencies / packaging
 
-### 4.1 Matriz redundante
-`pythonapp.yml`: roda `ubuntu-22.04`, `ubuntu-24.04`, `ubuntu-latest` em paralelo. `ubuntu-latest` hoje é `24.04` (vai virar `26.04` em algum momento). Tem teste duplicado. Manter `ubuntu-22.04` + `ubuntu-latest` cobre o útil.
+### 3.1 [MEDIUM] `setup.py:36` lists `configparser` (Py2 backport) — redundant on Py3
 
-### 4.2 Sem cache de pip
-Nenhum step usa `actions/setup-python` com `cache: pip`. Cada job baixa dependências do zero (~4 jobs * 4 Python versions = 16 instalações). Adicionar `cache: pip` corta minutos de CI.
+`configparser` has been part of the standard library since Python 3.0. Listing it forces users to download a useless package.
 
-### 4.3 `--cov-fail-under=77` é baixo demais
-Coverage gate é 77%. Vale checar onde está o gap (provavelmente `load_aws_config` e ramos de erro). Subir progressivamente.
+### 3.2 [MEDIUM] `setup.py:39` lists `boto3` in `install_requires` with no direct use
 
-### 4.4 Workflows sem `permissions:` mínimo
-Nenhum YAML define `permissions:` — runs herdam o default do repo. Boa prática é `permissions: contents: read` no topo e elevar por job (e.g. `packages: write` só onde publica imagem).
+The code imports `botocore` only (`from botocore import crt, awsrequest` etc.). `boto3` drags in `s3transfer` and other heavy dependencies (~10 MB extra). Remove it.
 
-### 4.5 Sem job de lint dedicado para o Dockerfile
-`hadolint` seria útil; o `Dockerfile` atual tem `pip install --user botocore` no estágio builder (linha 11) que é redundante com o `pip install /app-source-dir` da linha 15.
+### 3.3 [MEDIUM] `setup.py` is missing `python_requires`
 
----
+CI exercises Py 3.10 / 3.11 / 3.12 / 3.13, but the package allows `pip install` on any version. The `dict[str, str]` type hint in `tests/unit_test.py:77` breaks on <3.9. Add `python_requires=">=3.10"`.
 
-## 5. Documentação / governança
+### 3.4 [LOW] No `MANIFEST.in` despite `setup.py` reading `README.md` for `long_description`
 
-- `README.md` lista opções em uma seção "Options" copiada à mão; já desatualizou (não menciona `--tls-min`/`--tls-max`). Gerar via `argparse-manpage` ou similar evita drift.
-- `DEVELOP.md` tem 11 linhas; instruções de venv local estão escondidas no `Makefile`. Unir.
-- `.github/PULL_REQUEST_TEMPLATE.md` não foi auditado aqui, mas vale conferir se pede checklist de testes.
-- Não há `SECURITY.md` orientando como reportar CVE — adicionar.
-- Não há `CHANGELOG.md`; releases ficam só no GitHub.
+`setup.py:9-10` calls `open("README.md")` at build time. Modern setuptools includes `README.md` in the sdist by default, but it is fragile; adding `MANIFEST.in` with `include README.md LICENSE` makes the sdist install robust.
 
----
+### 3.5 [LOW] Publish workflow still uses `python setup.py sdist bdist_wheel`
 
-## 6. Lista priorizada (para discutir o que atacar primeiro)
+`scripts/pypi_publish.sh:5` and `.github/workflows/pythonpublish.yml:23`. setuptools deprecated the direct invocation; use `python -m build`.
 
-1. **Tirar chaves AWS dos testes** (§1.1) — fix isolado em `tests/integration_test.py`, requer rotação na AWS.
-2. **Não logar credenciais em `--verbose`** (§1.2) — patch de ~5 linhas em `inner_main`.
-3. **Consertar `x-amz-security-token` inconsistente** (§1.3) — afeta SigV4 com token vazio; testes precisam ajustar.
-4. **Pinar deps mínimas em `requirements.txt` + `setup.py`** (§1.4, §3.1, §3.2, §3.3).
-5. **Fix de parsing** (§2.1, §2.3) — bugs sutis com payloads reais.
-6. **`load_aws_config` while/break invertido** (§2.2).
-7. **Comportamento de `-o`** (§2.4, §2.5).
-8. **`utcnow()` deprecation** (§2.6).
-9. **CI permissions/cache/matrix** (§4.x).
-10. **Limpeza/refactor** (§2.9-2.13, §3.5, §3.6).
+### 3.6 [LOW] `pyrightconfig.json` is orphaned
+
+The file exists but no CI step runs pyright (only `mypy`). Either start using it (replace `mypy` with `pyright` in `pythonapp.yml`) or remove the file.
 
 ---
 
-## 7. Como verifiquei
+## 4. CI / CD
 
-- Leitura integral de: `awscurl/{awscurl.py,utils.py,__main__.py,__init__.py}`, `setup.py`, `setup.cfg`, `requirements*.txt`, `Dockerfile`, `Makefile`, `scripts/*`, `tests/*`, `.github/workflows/*`, `.github/{dependabot.yml,CODEOWNERS,copilot-instructions.md}`, `ci/*/Dockerfile`.
-- `pycodestyle -v awscurl` → 0 issues.
-- `mypy awscurl/ tests/` → 0 issues.
-- `pytest` offline (excluindo `integration_test.py` e `tls_test.py::TestHTTPSDefaultTLS`) → 23 passed.
-- Decodificação fora-da-árvore das strings base64 em `integration_test.py` para confirmar que os bytes formam um access key + secret válidos no formato AWS (não reproduzidos aqui).
-- Histórico de commits via `git log --oneline -20` para entender baseline e PRs recentes (#235, #232-#234).
+### 4.1 Redundant matrix
+
+`pythonapp.yml` runs `ubuntu-22.04`, `ubuntu-24.04`, and `ubuntu-latest` in parallel. `ubuntu-latest` currently resolves to `24.04` (it will become `26.04` at some point). Keeping `ubuntu-22.04` plus `ubuntu-latest` already covers the useful cases.
+
+### 4.2 No pip cache
+
+No step uses `actions/setup-python` with `cache: pip`. Each job downloads dependencies from scratch (4 OS jobs * 4 Python versions = 16 installs). Adding `cache: pip` saves CI minutes.
+
+### 4.3 `--cov-fail-under=77` is low
+
+The coverage gate is 77%. Worth investigating where the gap is (likely `load_aws_config` and error branches) and raising it incrementally.
+
+### 4.4 Workflows do not set minimum `permissions:`
+
+No workflow YAML defines `permissions:` — every run inherits the repo default. Good practice is `permissions: contents: read` at the top of each workflow and elevating per job (for example `packages: write` only where the image is published).
+
+### 4.5 No dedicated Dockerfile lint job
+
+`hadolint` would help. The current `Dockerfile` has `pip install --user botocore` in the builder stage (line 11) that is redundant with the `pip install /app-source-dir` on line 15.
+
+---
+
+## 5. Documentation / governance
+
+- `README.md` lists CLI options in a hand-curated "Options" section; it is already out of date (it does not mention `--tls-min` / `--tls-max`). Generating it from argparse (e.g. via `argparse-manpage`) would prevent drift.
+- `DEVELOP.md` has 11 lines; local venv instructions are hidden inside the `Makefile`. Worth merging.
+- `.github/PULL_REQUEST_TEMPLATE.md` was not audited here, but worth checking whether it requests a test checklist.
+- There is no `SECURITY.md` telling reporters how to disclose CVEs — add one.
+- There is no `CHANGELOG.md`; release notes live only on GitHub.
+
+---
+
+## 6. Prioritized list (for choosing what to attack first)
+
+1. **Remove AWS keys from tests** (section 1.1) — isolated change in `tests/integration_test.py`, requires rotation in AWS.
+2. **Stop logging credentials in `--verbose`** (section 1.2) — roughly 5-line patch in `inner_main`.
+3. **Fix the inconsistent `x-amz-security-token` logic** (section 1.3) — affects SigV4 with empty token; tests need to be adjusted.
+4. **Pin minimum dependency versions in `requirements.txt` and `setup.py`** (sections 1.4, 3.1, 3.2, 3.3).
+5. **Parsing fixes** (sections 2.1, 2.3) — subtle bugs that hit real payloads.
+6. **`load_aws_config` while/break inversion** (section 2.2).
+7. **`-o` behavior** (sections 2.4, 2.5).
+8. **`utcnow()` deprecation** (section 2.6).
+9. **CI permissions / cache / matrix** (section 4.x).
+10. **Cleanup / refactor** (sections 2.9-2.13, 3.5, 3.6).
+
+---
+
+## 7. How this checkup was produced
+
+- Full reads of: `awscurl/{awscurl.py,utils.py,__main__.py,__init__.py}`, `setup.py`, `setup.cfg`, `requirements*.txt`, `Dockerfile`, `Makefile`, `scripts/*`, `tests/*`, `.github/workflows/*`, `.github/{dependabot.yml,CODEOWNERS,copilot-instructions.md}`, `ci/*/Dockerfile`.
+- `pycodestyle -v awscurl` -> 0 issues.
+- `mypy awscurl/ tests/` -> 0 issues.
+- Offline `pytest` (excluding `integration_test.py` and `tls_test.py::TestHTTPSDefaultTLS`) -> 23 passed.
+- Out-of-tree decoding of the base64 strings in `integration_test.py` to confirm that the bytes form a valid AWS access key + secret pair (the values themselves are not reproduced here).
+- `git log --oneline -20` for baseline and recent PR history (#235, #232-#234).


### PR DESCRIPTION
## Summary
- Adds `CHECKUP.md` to the repo: a read-only inventory of the security issues, functional bugs, packaging smells, and CI/CD gaps found while reviewing `awscurl` on branch `claude/repo-checkup-review-EPd3L`.
- Docs-only PR. No source files are modified; the audit document is meant to be reviewed and used to plan follow-up fixes.

## Problems addressed
This PR does not fix code — it documents the problems so they can be triaged. The audit catalogues, among others:

- **High** — `tests/integration_test.py:33-34` (and three other lines) commits a base64-obfuscated AWS access key + secret. Symptom: real-looking AWS credentials live in the repo history. Root cause: tests were written to hit live S3 with embedded creds instead of using env vars / mocked clients.
- **High** — `awscurl/awscurl.py:608-609` calls `__log(vars(args))` when `--verbose` is set; `vars(args)` contains `access_key`, `secret_key`, `security_token`, `session_token`. Symptom: credentials leak to stderr. Root cause: no redaction step before logging.
- **High** — `awscurl/awscurl.py:243-244` (`task_1`) gates `x-amz-security-token` on truthiness while `awscurl/awscurl.py:371-372` (`task_4`) gates it on `is not None`. Symptom: with an empty-string token the header is sent but not signed → SigV4 mismatch. Root cause: inconsistent guard logic between the two stages.
- **High** — `requirements.txt` and `setup.py:34-42` have no version pins. Symptom: CI pulls "latest" every run; supply-chain risk. Root cause: missing dependency policy.
- **Medium** — `__normalize_query_string` (`awscurl/awscurl.py:384-391`) uses `split("=")` instead of `split("=", 1)`; values such as `token=abc=def` get truncated to `token=abc`.
- **Medium** — `inner_main` (`awscurl/awscurl.py:623`) parses headers with `split(": ")`, which raises `ValueError` on `-H "Authorization: Bearer foo: bar"`.
- **Medium** — `load_aws_config` (`awscurl/awscurl.py:480-494`) uses a `while True / break` pattern with inverted logic; if the caller passes `access_key` but not `secret_key`, the function exits before reading `secret_key` from the file.
- **Medium** — `-o` always duplicates the response body to stdout (`awscurl/awscurl.py:660-669`), and `--data-binary` (a request flag) controls the response file write mode.
- **Medium** — `__now()` uses `datetime.datetime.utcnow()` (deprecated on Python 3.12+).
- **Medium** — `dockerhubpublish.yml:14` uses `DOCKER_PASSWORD`; `pythonpublish.yml:21-22` uses `TWINE_USERNAME` / `TWINE_PASSWORD` instead of trusted publishing.
- **Low** — duplicate imports, orphan `pyrightconfig.json`, `boto3` listed but unused, `configparser` backport on Py3, Dockerfile base images not pinned by digest, missing `permissions:` block and pip cache in CI workflows.

The full list (with one section per finding and a prioritized backlog) lives in the new `CHECKUP.md`.

## Changes
- Added `CHECKUP.md` at the repository root (240+ lines) containing:
  - Executive summary table with severity counts.
  - Security section (1.1-1.9).
  - Functional bugs section (2.1-2.13).
  - Dependencies / packaging section (3.1-3.6).
  - CI / CD section (4.1-4.5).
  - Documentation / governance section.
  - Prioritized backlog of follow-up fixes.
  - Reproducibility appendix listing every command run during the audit.
- Translated the document to English to comply with the project's "all checked-in artifacts in English" rule.

## Test plan
- [x] `pycodestyle -v awscurl` -> 0 issues
- [x] `mypy awscurl/ tests/` -> `Success: no issues found in 12 source files`
- [x] Offline `pytest` (unit + stages + url_parsing + load_aws_config + basic) -> 23/23 passing
- [x] `grep -nE 'AKIA|zEPl|QUtJQU|ekVQ' CHECKUP.md` -> no literal credentials present (only a description of the issue, no decoded keys), so push protection does not trip
- [ ] No integration tests run (they require network + live AWS credentials)
- [ ] No production code changed; behavioral tests not applicable

https://claude.ai/code/session_01G7oKdMULqEcQNrfjSqaCq3