### PR TITLE
Fix: --data-binary GET crash and redirect re-signing

### DIFF
--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -19,7 +19,7 @@ from botocore import crt, awsrequest
 from botocore.credentials import Credentials
 from typing import Dict
 import urllib
-from urllib.parse import quote
+from urllib.parse import quote, urljoin
 from urllib3.util.ssl_ import create_urllib3_context
 
 import configparser
@@ -469,13 +469,27 @@ def __send_request(uri, data, headers, method, verify, allow_redirects, tls_min,
             __log('\nFOLLOWING REDIRECT (unsigned)+++++++++++++++++++++++++++')
             __log('Redirect URL = ' + redirect_url)
 
+            # Resolve relative redirect targets against the response URL
+            # to avoid MissingSchema errors (e.g. Location: /login)
+            redirect_url = urljoin(response.url, redirect_url)
+
             # Follow redirect WITHOUT signing (important for presigned URLs)
             # Strip only Authorization and AWS signing headers, keep user headers
             redirect_headers = {k: v for k, v in headers.items() if k not in
                                 ('Authorization', 'x-amz-date',
                                  'x-amz-content-sha256', 'x-amz-security-token')}
 
-            response = requests.request('GET', redirect_url, headers=redirect_headers,
+            # 301/302/303: follow with GET (303 explicitly changes method to GET)
+            # 307/308: preserve original method and body
+            if response.status_code in (301, 302, 303):
+                follow_method = 'GET'
+                follow_data = None
+            else:  # 307, 308
+                follow_method = method
+                follow_data = data
+
+            response = requests.request(follow_method, redirect_url,
+                                        headers=redirect_headers, data=follow_data,
                                         verify=verify, allow_redirects=True)
 
             __log('\nREDIRECT RESPONSE++++++++++++++++++++++++++++++++++++')

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -4,7 +4,7 @@ Awscurl implementation
 """
 from __future__ import print_function
 
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Tuple, Union
 
 import datetime
 import hashlib
@@ -80,7 +80,7 @@ def make_request(method: str,
                  service: str,
                  region: str,
                  uri: str,
-                 headers: Dict[str, str],
+                 headers: MutableMapping[str, str],
                  data: Union[str, bytes],
                  access_key: str,
                  secret_key: str,
@@ -190,7 +190,7 @@ def remove_default_port(parsed_url):
 # pylint: disable=too-many-arguments,too-many-locals
 def task_1_create_a_canonical_request(
         query,
-        headers: Mapping[str, str],
+        headers: MutableMapping[str, str],
         port,
         host,
         amzdate,
@@ -231,7 +231,8 @@ def task_1_create_a_canonical_request(
 
     # Step 4: Create payload hash (hash of the request body content). For GET
     # requests, the payload is an empty string ("").
-    payload_hash = sha256_hash_for_binary_data(data) if data_binary else sha256_hash(data)
+    # Only use binary hash if data is present AND data_binary flag is set.
+    payload_hash = sha256_hash_for_binary_data(data) if (data_binary and data) else sha256_hash(data or '')
 
     # Step 5: Create the canonical headers and signed headers. Header names
     # and value must be trimmed and lowercase, and sorted in ASCII order.
@@ -451,13 +452,34 @@ def __send_request(uri, data, headers, method, verify, allow_redirects, tls_min,
         if min_ver > max_ver:
             raise ValueError('--tls-min ({}) must not exceed --tls-max ({})'.format(tls_min, tls_max))
 
+    # Always disable automatic redirects for signed requests
+    # We'll handle redirects manually to avoid re-signing presigned URLs
     with requests.Session() as session:
         if tls_min is not None or tls_max is not None or not verify:
             session.mount('https://', _TLSAdapter(tls_min=tls_min, tls_max=tls_max, verify=verify))
-        response = session.request(method, uri, headers=headers, data=data, verify=verify, allow_redirects=allow_redirects)
+        response = session.request(method, uri, headers=headers, data=data, verify=verify, allow_redirects=False)
 
     __log('\nRESPONSE++++++++++++++++++++++++++++++++++++')
     __log('Response code: %d\n' % response.status_code)
+
+    # If user wants to follow redirects and we got a redirect response
+    if allow_redirects and response.status_code in (301, 302, 303, 307, 308):
+        redirect_url = response.headers.get('Location')
+        if redirect_url:
+            __log('\nFOLLOWING REDIRECT (unsigned)+++++++++++++++++++++++++++')
+            __log('Redirect URL = ' + redirect_url)
+
+            # Follow redirect WITHOUT signing (important for presigned URLs)
+            # Strip only Authorization and AWS signing headers, keep user headers
+            redirect_headers = {k: v for k, v in headers.items()
+                              if k not in ('Authorization', 'x-amz-date',
+                                           'x-amz-content-sha256', 'x-amz-security-token')}
+
+            response = requests.request('GET', redirect_url, headers=redirect_headers,
+                                        verify=verify, allow_redirects=True)
+
+            __log('\nREDIRECT RESPONSE++++++++++++++++++++++++++++++++++++')
+            __log('Response code: %d\n' % response.status_code)
 
     return response
 

--- a/awscurl/awscurl.py
+++ b/awscurl/awscurl.py
@@ -471,9 +471,9 @@ def __send_request(uri, data, headers, method, verify, allow_redirects, tls_min,
 
             # Follow redirect WITHOUT signing (important for presigned URLs)
             # Strip only Authorization and AWS signing headers, keep user headers
-            redirect_headers = {k: v for k, v in headers.items()
-                              if k not in ('Authorization', 'x-amz-date',
-                                           'x-amz-content-sha256', 'x-amz-security-token')}
+            redirect_headers = {k: v for k, v in headers.items() if k not in
+                                ('Authorization', 'x-amz-date',
+                                 'x-amz-content-sha256', 'x-amz-security-token')}
 
             response = requests.request('GET', redirect_url, headers=redirect_headers,
                                         verify=verify, allow_redirects=True)


### PR DESCRIPTION
## Summary

This PR fixes two remaining bugs reported in PR #223. **Bug #2 (binary `-o` file corruption)** is already resolved in **PR #243**.

---

## Bugs Fixed

### 1. GET with --data-binary Crashes (Fixes #223 Bug #1)
**Issue**: `sha256_hash_for_binary_data(None)` crashes when `data_binary=True` on GET requests

**Fix**:
```python
# Before:
payload_hash = sha256_hash_for_binary_data(data) if data_binary else sha256_hash(data)

# After:
payload_hash = sha256_hash_for_binary_data(data) if (data_binary and data) else sha256_hash(data or '')
```

### 2. HTTP Redirects Re-signed with SigV4 (Fixes #220 / #223 Bug #3)
**Issue**: Automatic redirects include Authorization header, breaking S3 presigned URLs

**Fix**: Manual redirect handling that strips only AWS auth headers while preserving user headers:
```python
# Disable automatic redirects
response = session.request(method, uri, headers=headers, data=data,
                           verify=verify, allow_redirects=False)

# Handle redirects manually
if allow_redirects and response.status_code in (301, 302, 303, 307, 308):
    redirect_url = response.headers.get('Location')
    if redirect_url:
        # Strip only AWS auth headers, keep user headers
        redirect_headers = {k: v for k, v in headers.items() if k not in
                            ('Authorization', 'x-amz-date',
                             'x-amz-content-sha256', 'x-amz-security-token')}
        response = requests.request('GET', redirect_url, headers=redirect_headers,
                                    verify=verify, allow_redirects=True)
```

---

## Type Annotation Fix

Updated `make_request` and `task_1_create_a_canonical_request` to use `MutableMapping[str, str]` instead of `Dict[str, str]` / `Mapping[str, str]`, matching the actual type used at runtime (from PR #244).

---

## Related

- **Bug #2 fix**: PR #243 - https://github.com/okigan/awscurl/pull/243 (merged)
- **Original PR**: PR #223 (still open, marked as having Bug #2 resolved)